### PR TITLE
`ethereum-light-client`: move beacon block verification

### DIFF
--- a/crates/sui-framework/packages/dwallet-system/sources/eth_dwallet.move
+++ b/crates/sui-framework/packages/dwallet-system/sources/eth_dwallet.move
@@ -10,9 +10,9 @@ module dwallet_system::eth_dwallet {
     use dwallet::tx_context::TxContext;
 
     use dwallet_system::dwallet;
-    use dwallet_system::dwallet::{DWalletCap, MessageApproval};
-    use dwallet_system::dwallet_2pc_mpc_ecdsa_k1::DWallet;
-    use dwallet_system::dwallet_2pc_mpc_ecdsa_k1::get_dwallet_cap_id;
+    use dwallet_system::dwallet::{get_dwallet_cap_id};
+    use dwallet_system::dwallet::{DWallet, DWalletCap, MessageApproval};
+    use dwallet_system::dwallet_2pc_mpc_ecdsa_k1::{Secp256K1};
     use dwallet_system::ethereum_state;
     use dwallet_system::ethereum_state::{EthereumState, LatestEthereumState};
 
@@ -44,51 +44,45 @@ module dwallet_system::eth_dwallet {
     /// Verifies the provided proof using the `verify_message_proof` native function.
     /// If the proof is valid, the message is approved.
     public fun approve_message(
-            eth_dwallet_cap: &EthereumDWalletCap,
-            message: vector<u8>,
-            dwallet: &DWallet,
-            latest_ethereum_state: &LatestEthereumState,
-            eth_state: &EthereumState,
-            proof: vector<u8>,
-            beacon_block: vector<u8>,
-            beacon_block_type: vector<u8>,
-            beacon_block_body: vector<u8>,
-            beacon_block_execution_payload: vector<u8>,
-        ): vector<MessageApproval> {
-            let latest_ethereum_state_id = object::id(latest_ethereum_state);
+        eth_dwallet_cap: &EthereumDWalletCap,
+        message: vector<u8>,
+        dwallet: &DWallet<Secp256K1>,
+        latest_ethereum_state: &LatestEthereumState,
+        eth_state: &EthereumState,
+        proof: vector<u8>,
+    ): vector<MessageApproval> {
+        let latest_ethereum_state_id = object::id(latest_ethereum_state);
 
-            // Validate that the Ethereum dWallet capability is for the correct network.
-            assert!(eth_dwallet_cap.latest_ethereum_state_id == latest_ethereum_state_id, EStateObjectMismatch);
+        // Validate that the Ethereum dWallet capability is for the correct network.
+        assert!(eth_dwallet_cap.latest_ethereum_state_id == latest_ethereum_state_id, EStateObjectMismatch);
 
-            // Validate that the EthereumState is for the correct network.
-            assert!(
-                latest_ethereum_state_id == ethereum_state::get_ethereum_state_latest_state_id(eth_state),
-                EStateObjectMismatch
-            );
+        // Validate that the EthereumState is for the correct network.
+        assert!(
+            latest_ethereum_state_id == ethereum_state::get_ethereum_state_latest_state_id(eth_state),
+            EStateObjectMismatch
+        );
 
-            // Validate that the Ethereum dWallet capability is for the correct DWallet.
-            let dwallet_cap_id = get_dwallet_cap_id(dwallet);
-            assert!(object::id(&eth_dwallet_cap.dwallet_cap) == dwallet_cap_id, EInvalidDWalletCap);
+        // Validate that the Ethereum dWallet capability is for the correct DWallet.
+        let dwallet_cap_id = get_dwallet_cap_id(dwallet);
+        assert!(object::id(&eth_dwallet_cap.dwallet_cap) == dwallet_cap_id, EInvalidDWalletCap);
 
-            let eth_state_data = ethereum_state::get_ethereum_state_data(eth_state);
-            let contract_address = ethereum_state::get_contract_address(latest_ethereum_state);
-            let data_slot = ethereum_state::get_contract_approved_transactions_slot(latest_ethereum_state);
+        let eth_state_state_root = ethereum_state::get_ethereum_state_state_root(eth_state);
+        let contract_address = ethereum_state::get_contract_address(latest_ethereum_state);
+        let data_slot = ethereum_state::get_contract_approved_transactions_slot(latest_ethereum_state);
 
-            let is_valid = verify_message_proof(
-                proof,
-                message,
-                object::id_to_bytes(&object::id(dwallet)),
-                data_slot,
-                beacon_block,
-                contract_address,
-                eth_state_data,
-                beacon_block_type,
-                beacon_block_body,
-                beacon_block_execution_payload,
-            );
-            assert!(is_valid, EInvalidStateProof);
-            dwallet::approve_messages(&eth_dwallet_cap.dwallet_cap, vector[message])
-        }
+        let is_valid = verify_message_proof(
+            proof,
+            message,
+            object::id_to_bytes(&object::id(dwallet)),
+            data_slot,
+            contract_address,
+            eth_state_state_root,
+        );
+        assert!(is_valid, EInvalidStateProof);
+
+        let message_approvals = dwallet::approve_messages(&eth_dwallet_cap.dwallet_cap, vector[message]);
+        message_approvals
+    }
 
     /// Verify the Message inside the Storage Merkle Root.
     native fun verify_message_proof(
@@ -96,11 +90,7 @@ module dwallet_system::eth_dwallet {
         message: vector<u8>,
         dwallet_id: vector<u8>,
         data_slot: u64,
-        beacon_block: vector<u8>,
         contract_address: vector<u8>,
-        eth_state_data: vector<u8>,
-        beacon_block_type: vector<u8>,
-        beacon_block_body: vector<u8>,
-        beacon_block_execution_payload: vector<u8>,
+        eth_state_state_root: vector<u8>,
     ): bool;
 }

--- a/crates/sui-framework/packages/dwallet-system/sources/ethereum_state.move
+++ b/crates/sui-framework/packages/dwallet-system/sources/ethereum_state.move
@@ -23,6 +23,7 @@ module dwallet_system::ethereum_state {
         data: vector<u8>,
         time_slot: u64,
         latest_ethereum_state_id: ID,
+        state_root: vector<u8>,
     }
 
     /// Latest Ethereum state object.
@@ -50,20 +51,19 @@ module dwallet_system::ethereum_state {
         updates_vec_arg: vector<u8>,
         finality_update_arg: vector<u8>,
         optimistic_update_arg: vector<u8>,
+        beacon_block: vector<u8>,
+        beacon_block_body: vector<u8>,
+        beacon_block_execution_payload: vector<u8>,
+        beacon_block_type: vector<u8>,
         ctx: &mut TxContext
     ) {
-        let (data, time_slot) = create_initial_eth_state_data(
-            state_bytes,
-            network,
-            updates_vec_arg,
-            finality_update_arg,
-            optimistic_update_arg
-        );
+        let (data, time_slot, state_root) = create_initial_eth_state_data(state_bytes, network, updates_vec_arg, finality_update_arg, optimistic_update_arg, beacon_block, beacon_block_body, beacon_block_execution_payload, beacon_block_type);
         let state = EthereumState {
             id: object::new(ctx),
             data,
             time_slot,
             latest_ethereum_state_id: object::id_from_address(@0x0),
+            state_root,
         };
 
         let latest_ethereum_state = LatestEthereumState {
@@ -81,13 +81,17 @@ module dwallet_system::ethereum_state {
     }
 
     /// Verifies the new Ethereum state according to the provided updates,
-    /// and updates the `LatestEthereumState` object if the new state is valid and has a newer time slot.
+    /// and updates the LatestEthereumState object if the new state is valid and has a newer time slot.
     public fun verify_new_state(
         updates_bytes: vector<u8>,
         finality_update_bytes: vector<u8>,
         optimistic_update_bytes: vector<u8>,
         latest_ethereum_state: &mut LatestEthereumState,
         eth_state: &EthereumState,
+        beacon_block: vector<u8>,
+        beacon_block_body: vector<u8>,
+        beacon_block_execution_payload: vector<u8>,
+        beacon_block_type: vector<u8>,
         ctx: &mut TxContext,
     ) {
         // Verify that the state is the latest state
@@ -99,21 +103,30 @@ module dwallet_system::ethereum_state {
         assert!(latest_ethereum_state_id == object::id(latest_ethereum_state), EStateObjectMismatch);
 
         let eth_state_bytes = get_ethereum_state_data(eth_state);
-        let (data, time_slot, network) = verify_eth_state(
+        let (data, time_slot, network, state_root) = verify_eth_state(
             updates_bytes,
             finality_update_bytes,
             optimistic_update_bytes,
             eth_state_bytes,
+            beacon_block,
+            beacon_block_body,
+            beacon_block_execution_payload,
+            beacon_block_type,
         );
 
         assert!(network == latest_ethereum_state.network, ENetworkMismatch);
-        assert!(time_slot > latest_ethereum_state.last_slot, EUpdateIrrelevant);
+        assert!(time_slot >= latest_ethereum_state.last_slot, EUpdateIrrelevant);
+
+        if(time_slot == latest_ethereum_state.last_slot) {
+            return
+        };
 
         let new_state = EthereumState {
             id: object::new(ctx),
             data,
             time_slot,
             latest_ethereum_state_id: object::id(latest_ethereum_state),
+            state_root,
         };
 
         latest_ethereum_state.eth_state_id = object::id(&new_state);
@@ -125,6 +138,12 @@ module dwallet_system::ethereum_state {
         latest_ethereum_state: &LatestEthereumState
     ): ID {
         latest_ethereum_state.eth_state_id
+    }
+
+    public(friend) fun get_ethereum_state_state_root(
+        state: &EthereumState
+    ): vector<u8> {
+        state.state_root
     }
 
     public(friend) fun get_latest_ethereum_state_network(
@@ -164,7 +183,11 @@ module dwallet_system::ethereum_state {
         finality_update: vector<u8>,
         optimistic_update: vector<u8>,
         eth_state: vector<u8>,
-    ): (vector<u8>, u64, vector<u8>);
+        beacon_block: vector<u8>,
+        beacon_block_body: vector<u8>,
+        beacon_block_execution_payload: vector<u8>,
+        beacon_block_type: vector<u8>,
+    ): (vector<u8>, u64, vector<u8>, vector<u8>);
 
     /// Native function.
     /// Creates the initial Ethereum state data with the given checkpoint.
@@ -174,5 +197,9 @@ module dwallet_system::ethereum_state {
         updates_vec_arg: vector<u8>,
         finality_update_arg: vector<u8>,
         optimistic_update_arg: vector<u8>,
-    ): (vector<u8>, u64);
+        beacon_block: vector<u8>,
+        beacon_block_body: vector<u8>,
+        beacon_block_execution_payload: vector<u8>,
+        beacon_block_type: vector<u8>,
+    ): (vector<u8>, u64, vector<u8>);
 }

--- a/crates/sui-types/src/eth_dwallet.rs
+++ b/crates/sui-types/src/eth_dwallet.rs
@@ -41,4 +41,5 @@ pub struct EthereumStateObject {
     pub data: Vec<u8>,
     pub time_slot: u64,
     pub latest_ethereum_state_id: ObjectID,
+    pub state_root: Vec<u8>,
 }

--- a/sui-execution/latest/sui-move-natives/src/eth_state_proof.rs
+++ b/sui-execution/latest/sui-move-natives/src/eth_state_proof.rs
@@ -34,6 +34,7 @@ use ssz_rs::Merkleized;
 use std::collections::VecDeque;
 use std::fs::File;
 use std::io::Read;
+use std::result;
 use std::str::FromStr;
 use tracing::log::error;
 use tracing::Instrument;
@@ -62,12 +63,8 @@ pub struct EthDWalletCostParams {
 *  message: vector<u8>,
 *  dwallet_id: vector<u8>,
 *  data_slot: u64,
-*  beacon_block: vector<u8>,
 *  contract_address: vector<u8>,
-*  eth_state_data: vector<u8>,
-*  beacon_block_type: vector<u8>,
-*  beacon_block_body: vector<u8>,
-*  beacon_block_execution_payload: vector<u8>): bool;`
+*  state_root: vector<u8>) -> bool;`
 * gas cost: verify_message_proof_cost_base | base cost for function call and fixed operations.
 **************************************************************************************************/
 pub fn verify_message_proof(
@@ -90,22 +87,7 @@ pub fn verify_message_proof(
 
     let cost = context.gas_used();
 
-    let (
-        beacon_block_execution_payload,
-        beacon_block_body,
-        beacon_block_type,
-        eth_state_data,
-        contract_address,
-        beacon_block,
-        map_slot,
-        dwallet_id,
-        message,
-        proof,
-    ) = (
-        pop_arg!(args, Vector).to_vec_u8()?,
-        pop_arg!(args, Vector).to_vec_u8()?,
-        pop_arg!(args, Vector).to_vec_u8()?,
-        pop_arg!(args, Vector).to_vec_u8()?,
+    let (state_root, contract_address, map_slot, dwallet_id, message, proof) = (
         pop_arg!(args, Vector).to_vec_u8()?,
         pop_arg!(args, Vector).to_vec_u8()?,
         pop_arg!(args, u64),
@@ -129,71 +111,6 @@ pub fn verify_message_proof(
     let contract_address: Address = contract_address
         .parse()
         .map_err(|_| PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT))?;
-
-    let mut beacon_block: BeaconBlock =
-        serde_json::from_str(&String::from_utf8(beacon_block).unwrap())
-            .map_err(|_| PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT))?;
-
-    let beacon_block_type = String::from_utf8(beacon_block_type.clone())
-        .map_err(|_| PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT))?;
-
-    let beacon_block_type: BeaconBlockType = BeaconBlockType::from_str(&beacon_block_type)
-        .map_err(|_| PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT))?;
-
-    let beacon_block_body =
-        BeaconBlockBodyWrapper::new_from_json(beacon_block_body, &beacon_block_type)
-            .map_err(|_| PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT))?;
-    let beacon_block_body: BeaconBlockBody = beacon_block_body.inner();
-
-    let beacon_block_execution_payload =
-        ExecutionPayloadWrapper::new_from_json(beacon_block_execution_payload, &beacon_block_type)
-            .map_err(|_| PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT))?;
-    let beacon_block_execution_payload: ExecutionPayload = beacon_block_execution_payload.inner();
-
-    let beacon_block_body = BeaconBlockBody::new_from_existing_with_execution_payload(
-        beacon_block_body,
-        beacon_block_execution_payload,
-    );
-    beacon_block.body = beacon_block_body;
-
-    let eth_state_data = bcs::from_bytes::<ConsensusStateManager<NimbusRpc>>(&eth_state_data)
-        .map_err(|_| PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT))?;
-
-    // Compute the root hash of the Merkle tree using the unverified (user-specified) beacon block.
-    let beacon_block_hash = beacon_block
-        .hash_tree_root()
-        .map_err(|_| PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR))?;
-
-    let mut verified_block_header = eth_state_data.get_finalized_header();
-
-    // Compute the root hash of the Merkle tree using the verified beacon header.
-    let verified_block_hash = verified_block_header
-        .hash_tree_root()
-        .map_err(|_| PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR))?;
-
-    // Verify the beacon block hash against the verified block hash.
-    // If the hashes match, it means we can trust the beacon block, and use its state
-    // root to verify the proof.
-    // More info in [Ethereum Consensus Specs](https://github.com/ethereum/consensus-specs/blob/fa09d896484bbe240334fa21ffaa454bafe5842e/ssz/simple-serialize.md#summaries-and-expansions).
-    if beacon_block_hash != verified_block_hash {
-        return Ok(NativeResult::ok(cost, smallvec![Value::bool(false)]));
-    }
-
-    // Verify that the `body_root` of the verified beacon block matches the actual root hash
-    // of the beacon block body.
-    let beacon_block_body_root = beacon_block
-        .body
-        .hash_tree_root()
-        .map_err(|_| PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR))?;
-    let beacon_block_body_root = Bytes32::try_from(beacon_block_body_root.as_ref())
-        .map_err(|_| PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR))?;
-
-    if verified_block_header.body_root != beacon_block_body_root {
-        return Ok(NativeResult::ok(cost, smallvec![Value::bool(false)]));
-    }
-
-    // Get the Execution layer's state root from the verified beacon block.
-    let state_root = beacon_block.body.execution_payload().state_root();
 
     let account_path = keccak256(contract_address.as_bytes()).to_vec();
     let account_encoded = encode_account(&proof);
@@ -241,7 +158,10 @@ pub fn verify_message_proof(
  * finality_update: vector<u8>,
  * optimistic_update: vector<u8>,
  * eth_state: vector<u8>,
- * should_apply_finality_update_first: bool) -> (vector<u8>, u64, vector<u8>, vector<u8>);`
+ * beacon_block: vector<u8>,
+ * beacon_block_body: vector<u8>,
+ * beacon_block_execution_payload: vector<u8>,
+ * beacon_block_type: vector<u8>) -> (vector<u8>, u64, vector<u8>, vector<u8>);`
  * gas cost: verify_eth_state_cost_base   | base cost for function call and fixed operations.
  **************************************************************************************************/
 pub(crate) fn verify_eth_state(
@@ -263,7 +183,20 @@ pub(crate) fn verify_eth_state(
     );
 
     let cost = context.gas_used();
-    let (current_eth_state, optimistic_update, finality_update, updates_vec) = (
+    let (
+        beacon_block_type,
+        beacon_block_execution_payload,
+        beacon_block_body,
+        beacon_block,
+        current_eth_state,
+        optimistic_update,
+        finality_update,
+        updates_vec,
+    ) = (
+        pop_arg!(args, Vector).to_vec_u8()?,
+        pop_arg!(args, Vector).to_vec_u8()?,
+        pop_arg!(args, Vector).to_vec_u8()?,
+        pop_arg!(args, Vector).to_vec_u8()?,
         pop_arg!(args, Vector).to_vec_u8()?,
         pop_arg!(args, Vector).to_vec_u8()?,
         pop_arg!(args, Vector).to_vec_u8()?,
@@ -290,10 +223,21 @@ pub(crate) fn verify_eth_state(
         optimistic_update,
     };
 
-    eth_state.advance_state(updates).map_err(|e| {
+    eth_state.advance_state(&updates).map_err(|e| {
         error!("failed to advance state: {:?}", e);
         PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
     })?;
+
+    let beacon_block = verify_beacon_block(
+        beacon_block_type,
+        beacon_block_execution_payload,
+        beacon_block_body,
+        beacon_block,
+        &mut eth_state,
+    )?;
+
+    // Get the Execution layer's state root from the verified beacon block.
+    let state_root = beacon_block.body.execution_payload().state_root();
 
     let new_state_bcs = bcs::to_bytes(&eth_state)
         .map_err(|_| PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR))?;
@@ -311,6 +255,7 @@ pub(crate) fn verify_eth_state(
             Value::vector_u8(new_state_bcs),
             Value::u64(slot),
             Value::vector_u8(network),
+            Value::vector_u8(state_root.as_slice().to_vec())
         ],
     ))
 }
@@ -318,8 +263,17 @@ pub(crate) fn verify_eth_state(
 /***************************************************************************************************
 * native fun create_initial_eth_state_data
 * Implementation of the Move native function
-* `eth_dwallet::create_initial_eth_state_data(state_bytes: vector<u8>, network: vector<u8>)
-* : (vector<u8>, u64);`
+* `eth_dwallet::create_initial_eth_state_data(
+* state_bytes: vector<u8>,
+* network: vector<u8>,
+* updates_vec: vector<u8>,
+* finality_update: vector<u8>,
+* optimistic_update: vector<u8>,
+* beacon_block: vector<u8>,
+* beacon_block_body: vector<u8>,
+* beacon_block_execution_payload: vector<u8>,
+* beacon_block_type: vector<u8>,
+* ) -> (vector<u8>, u64, vector<u8>);`
 * gas cost:
 * create_initial_eth_state_data_cost_base | base cost for function call and fixed operations.
 **************************************************************************************************/
@@ -353,6 +307,10 @@ pub(crate) fn create_initial_eth_state_data(
 
     let cost = context.gas_used();
 
+    let beacon_block_type = pop_arg!(args, Vector).to_vec_u8()?;
+    let beacon_block_execution_payload = pop_arg!(args, Vector).to_vec_u8()?;
+    let beacon_block_body = pop_arg!(args, Vector).to_vec_u8()?;
+    let beacon_block = pop_arg!(args, Vector).to_vec_u8()?;
     let optimistic_update = pop_arg!(args, Vector).to_vec_u8()?;
     let finality_update = pop_arg!(args, Vector).to_vec_u8()?;
     let updates_vec = pop_arg!(args, Vector).to_vec_u8()?;
@@ -396,6 +354,17 @@ pub(crate) fn create_initial_eth_state_data(
             PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
         })?;
 
+    let beacon_block = verify_beacon_block(
+        beacon_block_type,
+        beacon_block_execution_payload,
+        beacon_block_body,
+        beacon_block,
+        &eth_state,
+    )?;
+
+    // Get the Execution layer's state root from the verified beacon block.
+    let state_root = beacon_block.body.execution_payload().state_root();
+
     let state_bytes = bcs::to_bytes(&eth_state)
         .map_err(|_| PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR))?;
     let time_slot = eth_state.get_latest_slot();
@@ -403,7 +372,80 @@ pub(crate) fn create_initial_eth_state_data(
         cost,
         smallvec![
             Value::vector_u8(state_bytes),
-            Value::u64(time_slot.as_u64())
+            Value::u64(time_slot.as_u64()),
+            Value::vector_u8(state_root.as_slice().to_vec())
         ],
     ))
+}
+
+fn verify_beacon_block(
+    beacon_block_type: Vec<u8>,
+    beacon_block_execution_payload: Vec<u8>,
+    beacon_block_body: Vec<u8>,
+    beacon_block: Vec<u8>,
+    eth_state: &ConsensusStateManager<NimbusRpc>,
+) -> PartialVMResult<BeaconBlock> {
+    let mut beacon_block: BeaconBlock =
+        serde_json::from_str(&String::from_utf8(beacon_block).unwrap())
+            .map_err(|_| PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT))?;
+
+    let beacon_block_type = String::from_utf8(beacon_block_type.clone())
+        .map_err(|_| PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT))?;
+
+    let beacon_block_type: BeaconBlockType = BeaconBlockType::from_str(&beacon_block_type)
+        .map_err(|_| PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT))?;
+
+    let mut beacon_block_body =
+        BeaconBlockBodyWrapper::new_from_json(beacon_block_body, &beacon_block_type)
+            .map_err(|_| PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT))?;
+    let beacon_block_body: BeaconBlockBody = beacon_block_body.inner();
+
+    let beacon_block_execution_payload =
+        ExecutionPayloadWrapper::new_from_json(beacon_block_execution_payload, &beacon_block_type)
+            .map_err(|_| PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT))?;
+    let beacon_block_execution_payload: ExecutionPayload = beacon_block_execution_payload.inner();
+
+    let beacon_block_body = BeaconBlockBody::new_from_existing_with_execution_payload(
+        beacon_block_body,
+        beacon_block_execution_payload,
+    );
+    beacon_block.body = beacon_block_body;
+
+    // Compute the root hash of the Merkle tree using the unverified (user-specified) beacon block.
+    let beacon_block_hash = beacon_block
+        .hash_tree_root()
+        .map_err(|_| PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR))?;
+
+    let mut verified_block_header = eth_state.clone().get_finalized_header();
+
+    // Compute the root hash of the Merkle tree using the verified beacon header.
+    let verified_block_hash = verified_block_header
+        .hash_tree_root()
+        .map_err(|_| PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR))?;
+
+    // Verify the beacon block hash against the verified block hash.
+    // If the hashes match, it means we can trust the beacon block, and use its state
+    // root to verify the proof.
+    // More info in [Ethereum Consensus Specs](https://github.com/ethereum/consensus-specs/blob/fa09d896484bbe240334fa21ffaa454bafe5842e/ssz/simple-serialize.md#summaries-and-expansions).
+    if beacon_block_hash != verified_block_hash {
+        return Err(PartialVMError::new(
+            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
+        ));
+    }
+
+    // Verify that the `body_root` of the verified beacon block matches the actual root hash
+    // of the beacon block body.
+    let beacon_block_body_root = beacon_block
+        .body
+        .hash_tree_root()
+        .map_err(|_| PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR))?;
+    let beacon_block_body_root = Bytes32::try_from(beacon_block_body_root.as_ref())
+        .map_err(|_| PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR))?;
+
+    if verified_block_header.body_root != beacon_block_body_root {
+        return Err(PartialVMError::new(
+            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
+        ));
+    }
+    Ok(beacon_block)
 }


### PR DESCRIPTION
move beacon block verification to the state verification function instead of verifying when approving the message