### PR TITLE
fix: Make the DWallet MPC logic run asynchronously

### DIFF
--- a/crates/pera-core/src/consensus_validator.rs
+++ b/crates/pera-core/src/consensus_validator.rs
@@ -93,7 +93,7 @@ impl PeraTxValidator {
                 | ConsensusTransactionKind::CapabilityNotificationV2(_)
                 | ConsensusTransactionKind::RandomnessStateUpdate(_, _)
                 | ConsensusTransactionKind::DWalletMPCMessage(_, _, _)
-                | ConsensusTransactionKind::DWalletMPCOutput(_, _) => {}
+                | ConsensusTransactionKind::DWalletMPCOutput(..) => {}
             }
         }
 

--- a/crates/pera-core/src/dwallet_mpc/mod.rs
+++ b/crates/pera-core/src/dwallet_mpc/mod.rs
@@ -2,6 +2,7 @@ mod dkg;
 pub mod mpc_events;
 pub mod mpc_instance;
 pub mod mpc_manager;
+pub mod mpc_outputs_manager;
 pub mod mpc_party;
 mod presign;
 pub mod sign;

--- a/crates/pera-core/src/dwallet_mpc/mpc_events.rs
+++ b/crates/pera-core/src/dwallet_mpc/mpc_events.rs
@@ -1,5 +1,8 @@
 use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
+use pera_types::base_types::ObjectID;
 use pera_types::dwallet_mpc::DWALLET_2PC_MPC_ECDSA_K1_MODULE_NAME;
+use pera_types::error::PeraError;
+use pera_types::event::Event;
 use pera_types::{base_types::PeraAddress, id::ID, PERA_SYSTEM_ADDRESS};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -177,7 +180,7 @@ pub struct StartBatchedSignEvent {
     pub session_id: ID,
     /// An ordered list without duplicates of the messages we need to sign on.
     pub hashed_messages: Vec<Vec<u8>>,
-    initiating_user: PeraAddress,
+    pub initiating_user: PeraAddress,
 }
 
 impl StartBatchedSignEvent {

--- a/crates/pera-core/src/dwallet_mpc/mpc_outputs_manager.rs
+++ b/crates/pera-core/src/dwallet_mpc/mpc_outputs_manager.rs
@@ -1,0 +1,173 @@
+use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+use crate::dwallet_mpc::sign::BatchedSignSession;
+use anyhow::anyhow;
+use pera_types::base_types::{AuthorityName, ObjectID};
+use pera_types::committee::StakeUnit;
+use pera_types::messages_dwallet_mpc::{MPCRound, SessionInfo};
+use std::collections::{HashMap, HashSet};
+
+/// A struct to manage the DWallet MPC outputs.
+/// It stores all the outputs received for each instance, and decides whether an output is valid
+/// by checking if a validators with quorum of stake voted for it.
+pub struct DWalletMPCOutputsManager {
+    /// The batched sign sessions that are currently being processed.
+    pub batched_sign_sessions: HashMap<ObjectID, BatchedSignSession>,
+    /// The outputs received for each instance.
+    pub mpc_instances_outputs: HashMap<ObjectID, InstanceOutputsData>,
+    /// A mapping between an authority name to its stake.
+    pub weighted_parties: HashMap<AuthorityName, StakeUnit>,
+    /// The quorum threshold of the chain.
+    pub quorum_threshold: StakeUnit,
+}
+
+/// The data needed to manage the outputs of an MPC instance.
+#[derive(Clone)]
+pub struct InstanceOutputsData {
+    /// needed to easily check if any of the outputs received a quorum of votes and should be written to the chain
+    pub output_to_voting_authorities: HashMap<(Vec<u8>, SessionInfo), HashSet<AuthorityName>>,
+    /// Needed to make sure an authority does not send two outputs for the same session
+    pub authorities_that_sent_output: HashSet<AuthorityName>,
+}
+
+impl DWalletMPCOutputsManager {
+    pub fn new(epoch_store: &AuthorityPerEpochStore) -> Self {
+        DWalletMPCOutputsManager {
+            batched_sign_sessions: HashMap::new(),
+            quorum_threshold: epoch_store.committee().quorum_threshold(),
+            mpc_instances_outputs: HashMap::new(),
+            weighted_parties: epoch_store
+                .committee()
+                .voting_rights
+                .clone()
+                .into_iter()
+                .collect(),
+        }
+    }
+
+    /// Stores the given MPC output, and checks if any of the received outputs already received a quorum of votes.
+    /// If so, the output is returned along with a vector of malicious actors, i.e. parties that voted for other outputs.
+    // TODO (#311): Make validator don't mark other validators as malicious or take any active action while syncing
+    pub fn try_verify_output(
+        &mut self,
+        output: &Vec<u8>,
+        session_info: &SessionInfo,
+        origin_authority: AuthorityName,
+    ) -> anyhow::Result<OutputVerificationResult> {
+        let Some(ref mut session) = self.mpc_instances_outputs.get_mut(&session_info.session_id)
+        else {
+            return Ok(OutputVerificationResult::Malicious);
+        };
+        if session
+            .authorities_that_sent_output
+            .contains(&origin_authority)
+        {
+            return Ok(OutputVerificationResult::Malicious);
+        }
+        session
+            .authorities_that_sent_output
+            .insert(origin_authority.clone());
+        session
+            .output_to_voting_authorities
+            .entry((output.clone(), session_info.clone()))
+            .or_default()
+            .insert(origin_authority);
+        if let Some(agreed_output) =
+            session
+                .output_to_voting_authorities
+                .iter()
+                .find(|(output, voters)| {
+                    voters
+                        .iter()
+                        .map(|voter_name| self.weighted_parties.get(voter_name).unwrap_or(&0))
+                        .sum::<StakeUnit>()
+                        > self.quorum_threshold
+                })
+        {
+            let voted_for_other_outputs: Vec<AuthorityName> = session
+                .output_to_voting_authorities
+                .iter()
+                .filter(|(output, _)| *output != agreed_output.0)
+                .flat_map(|(_, voters)| voters)
+                .cloned()
+                .collect();
+            if let MPCRound::Sign(batch_session_id, hashed_message) = session_info.mpc_round.clone()
+            {
+                let batched_sign_session = self
+                    .batched_sign_sessions
+                    .get_mut(&batch_session_id)
+                    .ok_or(anyhow!(
+                        "failed to find batch for session id {}",
+                        batch_session_id
+                    ))?;
+                batched_sign_session
+                    .hashed_msg_to_signature
+                    .insert(hashed_message.clone(), output.clone());
+                if batched_sign_session.hashed_msg_to_signature.values().len()
+                    == batched_sign_session.ordered_messages.len()
+                {
+                    let new_output: Vec<Vec<u8>> = batched_sign_session
+                        .ordered_messages
+                        .iter()
+                        .map(|msg| {
+                            Ok(batched_sign_session
+                                .hashed_msg_to_signature
+                                .get(msg)
+                                .ok_or(anyhow!("failed to find message in batch {:?}", msg))?
+                                .clone())
+                        })
+                        .collect::<anyhow::Result<Vec<Vec<u8>>>>()?;
+                    return Ok(OutputVerificationResult::ValidWithNewOutput(
+                        bcs::to_bytes(&new_output)?,
+                        voted_for_other_outputs,
+                    ));
+                } else {
+                    return Ok(OutputVerificationResult::ValidWithoutOutput(
+                        voted_for_other_outputs,
+                    ));
+                }
+            }
+            return Ok(OutputVerificationResult::Valid(voted_for_other_outputs));
+        }
+        Ok(OutputVerificationResult::ValidWithoutOutput(vec![]))
+    }
+
+    pub fn handle_new_event(&mut self, session_info: &SessionInfo) {
+        if let MPCRound::BatchedSign(hashed_messages) = &session_info.mpc_round {
+            let mut seen = HashSet::new();
+            let messages_without_duplicates = hashed_messages
+                .clone()
+                .into_iter()
+                .filter(|x| seen.insert(x.clone()))
+                .collect();
+            self.batched_sign_sessions.insert(
+                session_info.session_id,
+                BatchedSignSession {
+                    hashed_msg_to_signature: HashMap::new(),
+                    ordered_messages: messages_without_duplicates,
+                },
+            );
+        } else {
+            self.mpc_instances_outputs.insert(
+                session_info.session_id,
+                InstanceOutputsData {
+                    output_to_voting_authorities: HashMap::new(),
+                    authorities_that_sent_output: HashSet::new(),
+                },
+            );
+        }
+    }
+}
+
+/// The possible results of verifying an incoming output for an MPC session.
+/// We need to differentiate between a duplicate & a malicious output, as the output can be sent twice by honest parties.
+#[derive(PartialOrd, PartialEq)]
+pub enum OutputVerificationResult {
+    /// When working on a batch, e.g. signing on a batch of messages, we write the output to the chain only once - when the entire batch is ready.
+    /// The returned value contains the new output, and the list of the malicious parties that voted for other outputs.
+    ValidWithNewOutput(Vec<u8>, Vec<AuthorityName>),
+    /// When the output is correct but not all the MPC flows in the batch have been completed.
+    ValidWithoutOutput(Vec<AuthorityName>),
+    Valid(Vec<AuthorityName>),
+    Duplicate,
+    Malicious,
+}

--- a/crates/pera-graphql-rpc/src/types/transaction_block_kind/mod.rs
+++ b/crates/pera-graphql-rpc/src/types/transaction_block_kind/mod.rs
@@ -16,7 +16,7 @@ use pera_types::transaction::TransactionKind as NativeTransactionKind;
 
 pub(crate) mod authenticator_state_update;
 pub(crate) mod consensus_commit_prologue;
-mod dwallet_mpc_output;
+pub mod dwallet_mpc_output;
 pub(crate) mod end_of_epoch;
 pub(crate) mod genesis;
 pub(crate) mod programmable;

--- a/crates/pera-node/src/lib.rs
+++ b/crates/pera-node/src/lib.rs
@@ -212,7 +212,9 @@ mod simulator {
 use simulator::*;
 
 use pera_core::consensus_handler::ConsensusHandlerInitializer;
+use pera_core::dwallet_mpc::mpc_instance::authority_name_to_party_id;
 use pera_core::dwallet_mpc::mpc_manager::DWalletMPCManager;
+use pera_core::dwallet_mpc::mpc_outputs_manager::DWalletMPCOutputsManager;
 use pera_core::safe_client::SafeClientMetricsBase;
 use pera_core::validator_tx_finalizer::ValidatorTxFinalizer;
 use pera_types::execution_config_utils::to_binary_config;
@@ -1293,7 +1295,11 @@ impl PeraNode {
         }
 
         epoch_store
-            .set_dwallet_mpc_manager(DWalletMPCManager::try_new(
+            .set_dwallet_mpc_outputs_manager(DWalletMPCOutputsManager::new(&epoch_store))
+            .await?;
+
+        epoch_store
+            .set_dwallet_mpc_sender(DWalletMPCManager::try_new(
                 Arc::new(consensus_adapter.clone()),
                 Arc::clone(&epoch_store),
                 epoch_store.epoch(),

--- a/crates/pera-types/src/messages_dwallet_mpc.rs
+++ b/crates/pera-types/src/messages_dwallet_mpc.rs
@@ -19,9 +19,10 @@ pub enum MPCRound {
     /// Contains the `ObjectId` of the dwallet object and the presign first round output.
     PresignSecond(ObjectID, Vec<u8>),
     /// The first round of the sign protocol.
-    /// Contains the party id associated with the decryption share, the object ID of the
-    /// batched sign session & the hashed message that is being signed.
-    Sign(PartyID, ObjectID, Vec<u8>),
+    /// Contains the object ID of the batched sign session & the hashed message that is being signed.
+    Sign(ObjectID, Vec<u8>),
+    /// A batched sign session, contains the list of messages that are being signed.
+    BatchedSign(Vec<Vec<u8>>),
 }
 
 /// The content of the system transaction that stores the MPC session output on chain.
@@ -52,6 +53,7 @@ pub struct SessionInfo {
     /// The address of the user that initiated this session.
     pub initiating_user_address: PeraAddress,
     /// The `DWalletCap` object's ID associated with the `DWallet`.
+    // TODO (#365): Remove DWallet cap ID from the [`SessionInfo`] struct and move it to the DKG second [`MPCRound`]
     pub dwallet_cap_id: ObjectID,
     /// The current MPC round in the protocol.
     /// Contains extra parameters if needed.

--- a/pera-execution/latest/pera-adapter/src/execution_engine.rs
+++ b/pera-execution/latest/pera-adapter/src/execution_engine.rs
@@ -1154,8 +1154,8 @@ mod checked {
                     CallArg::Pure(bcs::to_bytes(&dwallet_id).unwrap()),
                 ],
             ),
-            MPCRound::Sign(..) => {
-                let MPCRound::Sign(_, batch_session_id, _) = data.session_info.mpc_round else {
+            MPCRound::Sign(..) | MPCRound::BatchedSign(..) => {
+                let MPCRound::Sign(batch_session_id, _) = data.session_info.mpc_round else {
                     unreachable!("MPCRound is not sign for a sign session")
                 };
                 (


### PR DESCRIPTION
Until now the DWallet MPC logic ran synchronously and blocked the chain's consensus. As a result, one instance could block the chain and make it unusable, even for trivial stuff such as faucet requests. This PR mitigates this issue. 