### PR TITLE
fix: Send the MPC round number along every message

### DIFF
--- a/crates/dwallet-mpc-types/src/dwallet_mpc.rs
+++ b/crates/dwallet-mpc-types/src/dwallet_mpc.rs
@@ -63,7 +63,7 @@ pub type MPCRound = usize;
 pub enum MPCSessionStatus {
     Pending,
     FirstExecution,
-    Active(MPCRound),
+    Active,
     Finished(MPCPublicOutput, MPCPrivateOutput),
     Failed,
 }
@@ -73,7 +73,7 @@ impl fmt::Display for MPCSessionStatus {
         match self {
             MPCSessionStatus::Pending => write!(f, "Pending"),
             MPCSessionStatus::FirstExecution => write!(f, "FirstExecution"),
-            MPCSessionStatus::Active(round) => write!(f, "Active - round {}", round),
+            MPCSessionStatus::Active => write!(f, "Active"),
             MPCSessionStatus::Finished(public_output, private_output) => {
                 write!(f, "Finished({:?} {:?})", public_output, private_output)
             }

--- a/crates/pera-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/pera-core/src/authority/authority_per_epoch_store.rs
@@ -2564,7 +2564,7 @@ impl AuthorityPerEpochStore {
                 }
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::DWalletMPCMessage(authority, _, _),
+                kind: ConsensusTransactionKind::DWalletMPCMessage(message),
                 ..
             }) => {
                 // When sending an MPC message, the validator also includes its public key.
@@ -2572,10 +2572,10 @@ impl AuthorityPerEpochStore {
                 // the provided public key.
                 // This public key is later used
                 // to identify the authority that sent the MPC message.
-                if transaction.sender_authority() != *authority {
+                if transaction.sender_authority() != message.authority {
                     warn!(
                         "DWalletMPCMessage authority {} does not match its author from consensus {}",
-                        authority, transaction.certificate_author_index
+                        message.authority, transaction.certificate_author_index
                     );
                     return None;
                 }
@@ -3773,17 +3773,13 @@ impl AuthorityPerEpochStore {
                 Ok(ConsensusCertificateResult::ConsensusMessage)
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::DWalletMPCMessage(authority, message, session_id),
+                kind: ConsensusTransactionKind::DWalletMPCMessage(message),
                 ..
             }) => {
                 self.dwallet_mpc_sender
                     .get()
                     .ok_or(DwalletMPCError::MissingDWalletMPCSender)?
-                    .send(DWalletMPCChannelMessage::Message(
-                        message.clone(),
-                        *authority,
-                        *session_id,
-                    ))
+                    .send(DWalletMPCChannelMessage::Message(message.clone()))
                     .map_err(|err| DwalletMPCError::DWalletMPCSenderSendFailed(err.to_string()))?;
                 Ok(ConsensusCertificateResult::ConsensusMessage)
             }

--- a/crates/pera-core/src/consensus_validator.rs
+++ b/crates/pera-core/src/consensus_validator.rs
@@ -92,7 +92,7 @@ impl PeraTxValidator {
                 | ConsensusTransactionKind::NewJWKFetched(_, _, _)
                 | ConsensusTransactionKind::CapabilityNotificationV2(_)
                 | ConsensusTransactionKind::RandomnessStateUpdate(_, _)
-                | ConsensusTransactionKind::DWalletMPCMessage(_, _, _)
+                | ConsensusTransactionKind::DWalletMPCMessage(..)
                 | ConsensusTransactionKind::DWalletMPCOutput(..) => {}
                 ConsensusTransactionKind::LockNextCommittee(..) => {}
             }

--- a/crates/pera-core/src/dwallet_mpc/mod.rs
+++ b/crates/pera-core/src/dwallet_mpc/mod.rs
@@ -40,16 +40,6 @@ pub(crate) mod sign;
 
 pub const FIRST_EPOCH_ID: EpochId = 0;
 
-/// The message a Validator can send to the other parties while
-/// running a dWallet MPC session.
-#[derive(Clone)]
-pub struct DWalletMPCMessage {
-    /// The serialized message.
-    pub(crate) message: MPCMessage,
-    /// The authority (Validator) that sent the message.
-    pub(crate) authority: AuthorityName,
-}
-
 /// Convert a given authority name (address) to it's corresponding [`PartyID`].
 /// The [`PartyID`] is the index of the authority in the committee.
 pub(crate) fn authority_name_to_party_id(

--- a/crates/pera-types/src/messages_consensus.rs
+++ b/crates/pera-types/src/messages_consensus.rs
@@ -91,6 +91,19 @@ pub struct ConsensusTransaction {
     pub kind: ConsensusTransactionKind,
 }
 
+/// The message a Validator can send to the other parties while
+/// running a dWallet MPC session.
+#[derive(Clone, Debug, Serialize, Deserialize, Hash, PartialEq, Eq, Ord, PartialOrd)]
+pub struct DWalletMPCMessage {
+    /// The serialized message.
+    pub message: MPCMessage,
+    /// The authority (Validator) that sent the message.
+    pub authority: AuthorityName,
+    pub session_id: ObjectID,
+    /// The MPC round number, starts from 0.
+    pub round_number: usize,
+}
+
 #[derive(Serialize, Deserialize, Clone, Hash, PartialEq, Eq, Ord, PartialOrd)]
 pub enum ConsensusTransactionKey {
     Certificate(TransactionDigest),
@@ -662,16 +675,4 @@ fn test_jwk_compatibility() {
     let expected_id_bytes = vec![3, 97, 98, 99, 3, 100, 101, 102];
     let id_bcs = bcs::to_bytes(&id).unwrap();
     assert_eq!(id_bcs, expected_id_bytes);
-}
-
-/// The message a Validator can send to the other parties while
-/// running a dWallet MPC session.
-#[derive(Clone, Debug, Serialize, Deserialize, Hash, PartialEq, Eq, Ord, PartialOrd)]
-pub struct DWalletMPCMessage {
-    /// The serialized message.
-    pub message: MPCMessage,
-    /// The authority (Validator) that sent the message.
-    pub authority: AuthorityName,
-    pub session_id: ObjectID,
-    pub round_number: usize,
 }

--- a/crates/pera-types/src/messages_dwallet_mpc.rs
+++ b/crates/pera-types/src/messages_dwallet_mpc.rs
@@ -2,7 +2,7 @@ use crate::base_types::{ObjectID, PeraAddress};
 use crate::crypto::default_hash;
 use crate::digests::DWalletMPCOutputDigest;
 use crate::message_envelope::Message;
-use dwallet_mpc_types::dwallet_mpc::{DWalletMPCNetworkKey, MPCMessage, MPCPublicOutput};
+use dwallet_mpc_types::dwallet_mpc::{DWalletMPCNetworkKey, MPCPublicOutput};
 use serde::{Deserialize, Serialize};
 use shared_crypto::intent::IntentScope;
 

--- a/pera-execution/latest/pera-adapter/src/execution_engine.rs
+++ b/pera-execution/latest/pera-adapter/src/execution_engine.rs
@@ -6,7 +6,6 @@ pub use checked::*;
 #[pera_macros::with_checked_arithmetic]
 mod checked {
     use crate::execution_mode::{self, ExecutionMode};
-    use anyhow::Context;
     use dwallet_mpc_types::dwallet_mpc::{MPCPublicOutput, DWALLET_2PC_MPC_ECDSA_K1_MODULE_NAME};
     use move_binary_format::CompiledModule;
     use move_vm_runtime::move_vm::MoveVM;

--- a/pera-execution/latest/pera-adapter/src/execution_engine.rs
+++ b/pera-execution/latest/pera-adapter/src/execution_engine.rs
@@ -1185,8 +1185,8 @@ mod checked {
                 ],
             ),
             MPCRound::PresignSecond(dwallet_id, _first_round_output, batch_session_id) => {
-                let presigns: Vec<(ObjectID, MPCPublicOutput)> =
-                    bcs::from_bytes(&data.output).map_err(|e| {
+                let presigns: Vec<(ObjectID, MPCPublicOutput)> = bcs::from_bytes(&data.output)
+                    .map_err(|e| {
                         ExecutionError::new(
                             ExecutionErrorKind::DeserializationFailed,
                             Some(
@@ -1194,7 +1194,8 @@ mod checked {
                             ),
                         )
                     })?;
-                let first_round_session_ids: Vec<ObjectID> = presigns.iter().map(|(k, _)| *k).collect();
+                let first_round_session_ids: Vec<ObjectID> =
+                    presigns.iter().map(|(k, _)| *k).collect();
                 let presigns: Vec<MPCPublicOutput> = presigns.into_iter().map(|(_, v)| v).collect();
                 (
                     "create_batched_presign_output",


### PR DESCRIPTION
We need to know the round a message relates to, so messages from slow clients are ignored, and the validator that sent them isn't marked as malicious.

