### PR TITLE
chore: Verify the sign output by verifying the signature instead of by waiting for a quorum of sign outputs

### DIFF
--- a/crates/pera-core/src/authority.rs
+++ b/crates/pera-core/src/authority.rs
@@ -1547,10 +1547,10 @@ impl AuthorityState {
         epoch_store: &Arc<AuthorityPerEpochStore>,
         certificate: &VerifiedExecutableTransaction,
     ) -> PeraResult {
-        // The DWallet MPC components are not yet initialized in genesis TXs, and
-        // none of them should start DWallet-MPC flows
-        // Transactions that doesn't contain shared objects cannot trigger dwallet MPC flows,
-        // as they are not being ordered through the consensus engine
+        // The DWallet MPC components are not yet initialized in the genesis TXs.
+        // None of them should start DWallet-MPC flows.
+        // Transactions that don't contain shared objects cannot trigger dwallet MPC flows,
+        // as they are not being ordered through the consensus engine.
         if certificate.transaction_data().is_genesis_tx()
             || !self.is_validator(epoch_store)
             || !certificate.transaction_data().contains_shared_object()
@@ -1613,7 +1613,9 @@ impl AuthorityState {
     ) -> DwalletMPCResult<()> {
         let deserialized_event: ValidatorDataForNetworkDKG = bcs::from_bytes(&event.contents)?;
         epoch_store
-            .save_dwallet_mpc_message(DWalletMPCDBMessage::ValidatorDataForDKG(deserialized_event))
+            .save_dwallet_mpc_round_message(DWalletMPCDBMessage::ValidatorDataForDKG(
+                deserialized_event,
+            ))
             .await;
         Ok(())
     }

--- a/crates/pera-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/pera-core/src/authority/authority_per_epoch_store.rs
@@ -113,7 +113,8 @@ use pera_types::messages_consensus::{
 };
 use pera_types::messages_consensus::{DWalletMPCMessage, VersionedDkgConfirmation};
 use pera_types::messages_dwallet_mpc::{
-    DWalletMPCEvent, DWalletMPCOutput, DWalletMPCOutputMessage, SessionInfo,
+    DWalletMPCEvent, DWalletMPCLocalComputationMetadata, DWalletMPCOutput, DWalletMPCOutputMessage,
+    SessionInfo,
 };
 use pera_types::pera_system_state::epoch_start_pera_system_state::{
     EpochStartSystemState, EpochStartSystemStateTrait,
@@ -360,7 +361,6 @@ pub struct AuthorityPerEpochStore {
     dwallet_mpc_round_outputs: tokio::sync::Mutex<Vec<DWalletMPCOutputMessage>>,
     dwallet_mpc_round_events: tokio::sync::Mutex<Vec<DWalletMPCEvent>>,
     dwallet_mpc_round_completed_sessions: tokio::sync::Mutex<Vec<ObjectID>>,
-
     dwallet_mpc_manager: OnceCell<tokio::sync::Mutex<DWalletMPCManager>>,
 }
 
@@ -590,6 +590,8 @@ pub struct AuthorityEpochTables {
     /// round.
     pub(crate) dwallet_mpc_messages: DBMap<u64, Vec<DWalletMPCDBMessage>>,
     pub(crate) dwallet_mpc_outputs: DBMap<u64, Vec<DWalletMPCOutputMessage>>,
+    // TODO (#538): change type to the inner, basic type instead of using Sui's wrapper
+    // pub struct SessionID([u8; AccountAddress::LENGTH]);
     pub(crate) dwallet_mpc_completed_sessions: DBMap<u64, Vec<ObjectID>>,
     pub(crate) dwallet_mpc_events: DBMap<u64, Vec<DWalletMPCEvent>>,
 }

--- a/crates/pera-core/src/consensus_adapter.rs
+++ b/crates/pera-core/src/consensus_adapter.rs
@@ -974,7 +974,7 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
     /// This function is called multiple times, for each checkpoint after epoch end time.
     async fn close_epoch(&self, epoch_store: &Arc<AuthorityPerEpochStore>) {
         epoch_store
-            .save_dwallet_mpc_message(DWalletMPCDBMessage::StartLockNextEpochCommittee)
+            .save_dwallet_mpc_round_message(DWalletMPCDBMessage::StartLockNextEpochCommittee)
             .await;
         let dwallet_mpc_outputs_verifier = epoch_store.get_dwallet_mpc_outputs_verifier().await;
         if !dwallet_mpc_outputs_verifier.completed_locking_next_committee {

--- a/crates/pera-core/src/consensus_handler.rs
+++ b/crates/pera-core/src/consensus_handler.rs
@@ -49,7 +49,7 @@ use pera_types::error::PeraResult;
 use pera_types::executable_transaction::CertificateProof;
 use pera_types::message_envelope::VerifiedEnvelope;
 use pera_types::messages_dwallet_mpc::{
-    DWalletMPCEvent, DWalletMPCOutput, DWalletMPCOutputMessage, MPCRound, SessionInfo,
+    DWalletMPCEvent, DWalletMPCOutput, DWalletMPCOutputMessage, MPCInitProtocolInfo, SessionInfo,
 };
 use pera_types::{
     authenticator_state::ActiveJwk,
@@ -521,7 +521,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                                     // the verified output.
                                     // We can't preform this within the execution engine,
                                     // as it requires the class-groups crate from crypto-private lib.
-                                    if let MPCRound::NetworkDkg(key_scheme, _) =
+                                    if let MPCInitProtocolInfo::NetworkDkg(key_scheme, _) =
                                         session_info.mpc_round
                                     {
                                         let weighted_threshold_access_structure = match self
@@ -701,7 +701,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         )?;
 
         let mut new_session_info = session_info.clone();
-        new_session_info.mpc_round = MPCRound::NetworkDkg(key_scheme, Some(key));
+        new_session_info.mpc_round = MPCInitProtocolInfo::NetworkDkg(key_scheme, Some(key));
 
         Ok(self.create_dwallet_mpc_output_system_tx(&new_session_info, verified_output))
     }

--- a/crates/pera-core/src/consensus_handler.rs
+++ b/crates/pera-core/src/consensus_handler.rs
@@ -49,7 +49,7 @@ use pera_types::error::PeraResult;
 use pera_types::executable_transaction::CertificateProof;
 use pera_types::message_envelope::VerifiedEnvelope;
 use pera_types::messages_dwallet_mpc::{
-    DWalletMPCEvent, DWalletMPCOutput, DWalletMPCOutputMessage, MPCInitProtocolInfo, SessionInfo,
+    DWalletMPCEvent, DWalletMPCOutput, DWalletMPCOutputMessage, MPCProtocolInitData, SessionInfo,
 };
 use pera_types::{
     authenticator_state::ActiveJwk,
@@ -249,7 +249,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 
         let last_committed_round = self.last_consensus_stats.index.sub_dag_index;
 
-        // Check if the dwallet mpc manager should perform a state sync, and if so block consensus outputs processing & perform the state sync
         if self.should_perform_dwallet_mpc_state_sync().await {
             if let Err(err) = self.perform_dwallet_mpc_state_sync().await {
                 error!(
@@ -260,7 +259,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             }
         }
         let mut dwallet_mpc_verifier = self.epoch_store.get_dwallet_mpc_outputs_verifier().await;
-        dwallet_mpc_verifier.last_processed_round = last_committed_round;
+        dwallet_mpc_verifier.last_processed_consensus_round = last_committed_round;
         // Need to drop the verifier, as `self` is being used mutably later in this function
         drop(dwallet_mpc_verifier);
 
@@ -402,7 +401,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                         let mut dwallet_mpc_verifier =
                             self.epoch_store.get_dwallet_mpc_outputs_verifier().await;
                         self.epoch_store
-                            .save_dwallet_mpc_message(
+                            .save_dwallet_mpc_round_message(
                                 DWalletMPCDBMessage::LockNextEpochCommitteeVote(*authority),
                             )
                             .await;
@@ -463,6 +462,10 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                                     malicious_actors: vec![origin_authority],
                                 }
                             });
+                        let mut manager = self.epoch_store.get_dwallet_mpc_manager().await;
+                        manager.flag_authorities_as_malicious(
+                            &output_verification_result.malicious_actors,
+                        );
                         match output_verification_result.result {
                             OutputResult::Valid => {
                                 self.epoch_store
@@ -521,7 +524,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                                     // the verified output.
                                     // We can't preform this within the execution engine,
                                     // as it requires the class-groups crate from crypto-private lib.
-                                    if let MPCInitProtocolInfo::NetworkDkg(key_scheme, _) =
+                                    if let MPCProtocolInitData::NetworkDkg(key_scheme, _) =
                                         session_info.mpc_round
                                     {
                                         let weighted_threshold_access_structure = match self
@@ -701,7 +704,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         )?;
 
         let mut new_session_info = session_info.clone();
-        new_session_info.mpc_round = MPCInitProtocolInfo::NetworkDkg(key_scheme, Some(key));
+        new_session_info.mpc_round = MPCProtocolInitData::NetworkDkg(key_scheme, Some(key));
 
         Ok(self.create_dwallet_mpc_output_system_tx(&new_session_info, verified_output))
     }
@@ -765,21 +768,29 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             .collect())
     }
 
+    /// Check if the dWallet MPC manager should perform a state sync.
+    /// If so, block consensus and load all messages.
+    /// This condition is only true if we process a round
+    /// before we processed the previous round,
+    /// which can only happen if we restart the node.
     async fn should_perform_dwallet_mpc_state_sync(&self) -> bool {
         let mut dwallet_mpc_verifier = self.epoch_store.get_dwallet_mpc_outputs_verifier().await;
         // Check if the dwallet mpc manager should perform a state sync, and if so block consensus and load all messages
         // This condition is only true if we process a round before we processed the previous round,
         // which can only happen if we restart the node.
         self.last_consensus_stats.index.sub_dag_index
-            > dwallet_mpc_verifier.last_processed_round + 1
+            > dwallet_mpc_verifier.last_processed_consensus_round + 1
     }
 
     /// Syncs the [`DWalletMPCOutputsVerifier`] from the epoch start.
-    /// Needed to be performed here so system transactions will get created when they should & a fork in the
+    /// Needs to be performed here,
+    /// so system transactions will get created when they should, and a fork in the
     /// chain will be prevented.
     /// Fails only if the epoch switched in the middle of the state sync.
     async fn perform_dwallet_mpc_state_sync(&self) -> PeraResult {
-        info!("performs a state sync for the DWallet MPC node");
+        info!("Performing a state sync for the dWallet MPC node");
+        let mut manager = self.epoch_store.get_dwallet_mpc_manager().await;
+
         let mut dwallet_mpc_verifier = self.epoch_store.get_dwallet_mpc_outputs_verifier().await;
         let mut dwallet_mpc_batches_manager =
             self.epoch_store.get_dwallet_mpc_batches_manager().await;
@@ -794,6 +805,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 output.authority,
             ) {
                 Ok(result) => {
+                    manager.flag_authorities_as_malicious(&result.malicious_actors);
                     // TODO (#524): Handle malicious behavior.
                     if result.result == OutputResult::Valid {
                         if output.session_info.mpc_round.is_part_of_batch() {

--- a/crates/pera-core/src/dwallet_mpc/README.md
+++ b/crates/pera-core/src/dwallet_mpc/README.md
@@ -87,3 +87,6 @@ To generate the RPC schema, follow these steps:
 RUST_LOG=off,pera_node=info,pera_core=error;RUST_MIN_STACK=16777216 cargo run --bin pera -- start --with-faucet --force-regenesis --epoch-duration-ms 1000000000000
 ```
 
+## Testing the State Sync Mechanism Manually
+To test the state sync feature, uncomment the code in the `start` function located in `crates/pera/src/pera_commands.rs`.
+This code restarts a validator node 10 seconds after the chain starts.

--- a/crates/pera-core/src/dwallet_mpc/batches_manager.rs
+++ b/crates/pera-core/src/dwallet_mpc/batches_manager.rs
@@ -8,7 +8,7 @@ use crate::dwallet_mpc::mpc_session::AsyncProtocol;
 use dwallet_mpc_types::dwallet_mpc::{MPCMessage, MPCPublicOutput};
 use pera_types::base_types::ObjectID;
 use pera_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
-use pera_types::messages_dwallet_mpc::{MPCInitProtocolInfo, SessionInfo, SignMessageData};
+use pera_types::messages_dwallet_mpc::{MPCInitProtocolInfo, SessionInfo, SignSessionData};
 use std::collections::{HashMap, HashSet};
 
 /// Structs to hold the batches sign session data.
@@ -99,7 +99,7 @@ impl DWalletMPCBatchesManager {
         output: MPCPublicOutput,
     ) -> DwalletMPCResult<()> {
         match session_info.mpc_round {
-            MPCInitProtocolInfo::Sign(SignMessageData {
+            MPCInitProtocolInfo::Sign(SignSessionData {
                 batch_session_id,
                 message,
                 ..
@@ -127,7 +127,7 @@ impl DWalletMPCBatchesManager {
         session_info: &SessionInfo,
     ) -> DwalletMPCResult<Option<Vec<u8>>> {
         match session_info.mpc_round {
-            MPCInitProtocolInfo::Sign(SignMessageData {
+            MPCInitProtocolInfo::Sign(SignSessionData {
                 batch_session_id, ..
             }) => self.is_sign_batch_completed(batch_session_id),
             MPCInitProtocolInfo::PresignSecond(_, _, batch_session_id) => {

--- a/crates/pera-core/src/dwallet_mpc/batches_manager.rs
+++ b/crates/pera-core/src/dwallet_mpc/batches_manager.rs
@@ -8,7 +8,7 @@ use crate::dwallet_mpc::mpc_session::AsyncProtocol;
 use dwallet_mpc_types::dwallet_mpc::{MPCMessage, MPCPublicOutput};
 use pera_types::base_types::ObjectID;
 use pera_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
-use pera_types::messages_dwallet_mpc::{MPCInitProtocolInfo, SessionInfo, SignSessionData};
+use pera_types::messages_dwallet_mpc::{MPCProtocolInitData, SessionInfo, SingleSignSessionData};
 use std::collections::{HashMap, HashSet};
 
 /// Structs to hold the batches sign session data.
@@ -64,7 +64,7 @@ impl DWalletMPCBatchesManager {
     /// if the event is a start batch event.
     pub(crate) fn handle_new_event(&mut self, session_info: &SessionInfo) {
         match &session_info.mpc_round {
-            MPCInitProtocolInfo::BatchedSign(hashed_messages) => {
+            MPCProtocolInitData::BatchedSign(hashed_messages) => {
                 let mut seen = HashSet::new();
                 let messages_without_duplicates = hashed_messages
                     .clone()
@@ -79,7 +79,7 @@ impl DWalletMPCBatchesManager {
                     },
                 );
             }
-            MPCInitProtocolInfo::BatchedPresign(batch_size) => {
+            MPCProtocolInitData::BatchedPresign(batch_size) => {
                 self.batched_presign_sessions.insert(
                     session_info.session_id,
                     BatchedPresignSession {
@@ -99,14 +99,14 @@ impl DWalletMPCBatchesManager {
         output: MPCPublicOutput,
     ) -> DwalletMPCResult<()> {
         match session_info.mpc_round {
-            MPCInitProtocolInfo::Sign(SignSessionData {
+            MPCProtocolInitData::Sign(SingleSignSessionData {
                 batch_session_id,
                 message,
                 ..
             }) => {
                 self.store_verified_sign_output(batch_session_id, message.clone(), output)?;
             }
-            MPCInitProtocolInfo::PresignSecond(_, ref first_round_output, batch_session_id) => {
+            MPCProtocolInitData::PresignSecond(_, ref first_round_output, batch_session_id) => {
                 let presign =
                     parse_presign_from_first_and_second_outputs(first_round_output, &output)?;
                 self.store_verified_presign_output(
@@ -127,10 +127,10 @@ impl DWalletMPCBatchesManager {
         session_info: &SessionInfo,
     ) -> DwalletMPCResult<Option<Vec<u8>>> {
         match session_info.mpc_round {
-            MPCInitProtocolInfo::Sign(SignSessionData {
+            MPCProtocolInitData::Sign(SingleSignSessionData {
                 batch_session_id, ..
             }) => self.is_sign_batch_completed(batch_session_id),
-            MPCInitProtocolInfo::PresignSecond(_, _, batch_session_id) => {
+            MPCProtocolInitData::PresignSecond(_, _, batch_session_id) => {
                 self.is_presign_batch_completed(batch_session_id)
             }
             _ => Ok(None),

--- a/crates/pera-core/src/dwallet_mpc/batches_manager.rs
+++ b/crates/pera-core/src/dwallet_mpc/batches_manager.rs
@@ -8,7 +8,7 @@ use crate::dwallet_mpc::mpc_session::AsyncProtocol;
 use dwallet_mpc_types::dwallet_mpc::{MPCMessage, MPCPublicOutput};
 use pera_types::base_types::ObjectID;
 use pera_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
-use pera_types::messages_dwallet_mpc::{MPCRound, SessionInfo, SignMessageData};
+use pera_types::messages_dwallet_mpc::{MPCInitProtocolInfo, SessionInfo, SignMessageData};
 use std::collections::{HashMap, HashSet};
 
 /// Structs to hold the batches sign session data.
@@ -64,7 +64,7 @@ impl DWalletMPCBatchesManager {
     /// if the event is a start batch event.
     pub(crate) fn handle_new_event(&mut self, session_info: &SessionInfo) {
         match &session_info.mpc_round {
-            MPCRound::BatchedSign(hashed_messages) => {
+            MPCInitProtocolInfo::BatchedSign(hashed_messages) => {
                 let mut seen = HashSet::new();
                 let messages_without_duplicates = hashed_messages
                     .clone()
@@ -79,7 +79,7 @@ impl DWalletMPCBatchesManager {
                     },
                 );
             }
-            MPCRound::BatchedPresign(batch_size) => {
+            MPCInitProtocolInfo::BatchedPresign(batch_size) => {
                 self.batched_presign_sessions.insert(
                     session_info.session_id,
                     BatchedPresignSession {
@@ -99,14 +99,14 @@ impl DWalletMPCBatchesManager {
         output: MPCPublicOutput,
     ) -> DwalletMPCResult<()> {
         match session_info.mpc_round {
-            MPCRound::Sign(SignMessageData {
+            MPCInitProtocolInfo::Sign(SignMessageData {
                 batch_session_id,
                 message,
                 ..
             }) => {
                 self.store_verified_sign_output(batch_session_id, message.clone(), output)?;
             }
-            MPCRound::PresignSecond(_, ref first_round_output, batch_session_id) => {
+            MPCInitProtocolInfo::PresignSecond(_, ref first_round_output, batch_session_id) => {
                 let presign =
                     parse_presign_from_first_and_second_outputs(first_round_output, &output)?;
                 self.store_verified_presign_output(
@@ -127,10 +127,10 @@ impl DWalletMPCBatchesManager {
         session_info: &SessionInfo,
     ) -> DwalletMPCResult<Option<Vec<u8>>> {
         match session_info.mpc_round {
-            MPCRound::Sign(SignMessageData {
+            MPCInitProtocolInfo::Sign(SignMessageData {
                 batch_session_id, ..
             }) => self.is_sign_batch_completed(batch_session_id),
-            MPCRound::PresignSecond(_, _, batch_session_id) => {
+            MPCInitProtocolInfo::PresignSecond(_, _, batch_session_id) => {
                 self.is_presign_batch_completed(batch_session_id)
             }
             _ => Ok(None),

--- a/crates/pera-core/src/dwallet_mpc/cryptographic_computations_orchestrator.rs
+++ b/crates/pera-core/src/dwallet_mpc/cryptographic_computations_orchestrator.rs
@@ -1,0 +1,117 @@
+//! The orchestrator for DWallet MPC cryptographic computations.
+//!
+//! The orchestrator's job is to manage a task queue for computations
+//! and avoid launching tasks that cannot be parallelized at the moment
+//! due to unavailable CPUs.
+//! When a CPU core is freed, and before launching the Rayon task,
+//! it ensures that the computation has not become redundant based on
+//! messages received since it was added to the queue. This approach
+//! reduces the read delay from the local DB without slowing down state sync.
+use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+use crate::dwallet_mpc::mpc_session::DWalletMPCSession;
+use pera_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
+use pera_types::messages_dwallet_mpc::DWalletMPCLocalComputationMetadata;
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use tokio::sync::mpsc::UnboundedSender;
+
+/// The orchestrator for DWallet MPC cryptographic computations.
+///
+/// The orchestrator's job is to manage a task queue for computations
+/// and avoid launching tasks that cannot be parallelized at the moment
+/// due to unavailable CPUs.
+/// When a CPU core is freed, and before launching the Rayon task,
+/// it ensures that the computation has not become redundant based on
+/// messages received since it was added to the queue. This approach
+/// reduces the read delay from the local DB without slowing down state sync.
+pub(crate) struct CryptographicComputationsOrchestrator {
+    /// The number of logical CPUs available for cryptographic computations on the validator's
+    /// machine.
+    pub(crate) available_cores_for_cryptographic_computations: usize,
+    /// A channel sender to notify the manager that a computation has been completed.
+    /// This is needed to decrease the [`currently_running_sessions_count`] when a computation is
+    /// done.
+    pub(crate) completed_computation_channel_sender: UnboundedSender<()>,
+    /// A map of the pending cryptographic computation sessions.
+    /// This map is needed to remove a session that we received a quorum of messages for
+    /// its next round, so running the current completed round is redundant.
+    pub(crate) pending_computation_map:
+        HashMap<DWalletMPCLocalComputationMetadata, DWalletMPCSession>,
+    /// The order of the [`pending_computation_map`].
+    /// Needed to process the computations in the order they were received.
+    pub(crate) pending_for_computation_order: VecDeque<DWalletMPCLocalComputationMetadata>,
+    /// The number of currently running cryptographic computations - i.e.,
+    /// computations we called [`rayon::spawn_fifo`] for,
+    /// but we didn't receive a completion message for.
+    pub(crate) currently_running_sessions_count: usize,
+}
+
+impl CryptographicComputationsOrchestrator {
+    /// Creates a new orchestrator for cryptographic computations.
+    pub(crate) fn try_new(epoch_store: &Arc<AuthorityPerEpochStore>) -> DwalletMPCResult<Self> {
+        let completed_computation_channel_sender =
+            Self::listen_for_completed_computations(&epoch_store);
+        let available_cores_for_computations: usize = std::thread::available_parallelism()
+            .map_err(|e| DwalletMPCError::FailedToGetAvailableParallelism(e.to_string()))?
+            .into();
+        if !(available_cores_for_computations > 0) {
+            return Err(DwalletMPCError::InsufficientCPUCores);
+        }
+
+        Ok(CryptographicComputationsOrchestrator {
+            available_cores_for_cryptographic_computations: available_cores_for_computations,
+            completed_computation_channel_sender,
+            pending_computation_map: HashMap::new(),
+            pending_for_computation_order: VecDeque::new(),
+            currently_running_sessions_count: 0,
+        })
+    }
+
+    /// Insert the given list of pending sessions to the pending computations queue.
+    /// If there's an existing pending computation for an old round of one of the newer
+    /// computations, the obsolete computation is removed.
+    pub(crate) fn insert_ready_sessions(&mut self, sessions: Vec<DWalletMPCSession>) {
+        for session in sessions.into_iter() {
+            if session.pending_quorum_for_highest_round_number > 0 {
+                self.pending_computation_map
+                    .remove(&DWalletMPCLocalComputationMetadata {
+                        session_id: session.session_info.session_id,
+                        crypto_round_number: session.pending_quorum_for_highest_round_number - 1,
+                    });
+            }
+            let session_next_round_metadata = DWalletMPCLocalComputationMetadata {
+                session_id: session.session_info.session_id,
+                crypto_round_number: session.pending_quorum_for_highest_round_number,
+            };
+            self.pending_computation_map
+                .insert(session_next_round_metadata.clone(), session.clone());
+            self.pending_for_computation_order
+                .push_back(session_next_round_metadata);
+        }
+    }
+
+    fn listen_for_completed_computations(
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> UnboundedSender<()> {
+        let (completed_computation_channel_sender, mut completed_computation_channel_receiver) =
+            tokio::sync::mpsc::unbounded_channel();
+        let epoch_store_for_channel = epoch_store.clone();
+        tokio::spawn(async move {
+            loop {
+                match completed_computation_channel_receiver.recv().await {
+                    None => {
+                        break;
+                    }
+                    Some(_) => {
+                        epoch_store_for_channel
+                            .get_dwallet_mpc_manager()
+                            .await
+                            .cryptographic_computations_orchestrator
+                            .currently_running_sessions_count -= 1;
+                    }
+                }
+            }
+        });
+        completed_computation_channel_sender
+    }
+}

--- a/crates/pera-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/pera-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -1,6 +1,7 @@
-///! This module contains the DWalletMPCService struct.
-///! It is responsible to read DWallet MPC messages from the local DB every [`READ_INTERVAL_MILLIS`] seconds
-///! and forward them to the [`crate::dwallet_mpc::mpc_manager::DWalletMPCManager`].
+//! This module contains the DWalletMPCService struct.
+//! It is responsible to read DWallet MPC messages from the
+//! local DB every [`READ_INTERVAL_SECS`] seconds
+//! and forward them to the [`crate::dwallet_mpc::mpc_manager::DWalletMPCManager`].
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::dwallet_mpc::mpc_manager::DWalletMPCDBMessage;
 use dwallet_mpc_types::dwallet_mpc::MPCSessionStatus;
@@ -12,10 +13,10 @@ use tokio::sync::{watch, Notify};
 use tracing::error;
 use typed_store::Map;
 
-const READ_INTERVAL_MILLIS: u64 = 100;
+const READ_INTERVAL_MS: u64 = 100;
 
 pub struct DWalletMPCService {
-    last_read_narwhal_round: Round,
+    last_read_consensus_round: Round,
     read_messages: usize,
     epoch_store: Arc<AuthorityPerEpochStore>,
     epoch_id: EpochId,
@@ -26,7 +27,7 @@ pub struct DWalletMPCService {
 impl DWalletMPCService {
     pub fn new(epoch_store: Arc<AuthorityPerEpochStore>, exit: watch::Receiver<()>) -> Self {
         Self {
-            last_read_narwhal_round: 0,
+            last_read_consensus_round: 0,
             read_messages: 0,
             epoch_store: epoch_store.clone(),
             epoch_id: epoch_store.epoch(),
@@ -35,32 +36,35 @@ impl DWalletMPCService {
         }
     }
 
-    /// Spawns the DWallet MPC service, that
-    /// read DWallet MPC messages from the local DB every [`READ_INTERVAL_MILLIS`] seconds and forward them to the
-    /// [`crate::dwallet_mpc::mpc_manager::DWalletMPCManager`].
+    /// Starts the DWallet MPC service.
     ///
-    /// The service exists upon an epoch switch.
+    /// This service periodically reads DWallet MPC messages from the local database
+    /// at intervals defined by [`READ_INTERVAL_SECS`] seconds.
+    /// The messages are then forwarded to the
+    /// [`crate::dwallet_mpc::mpc_manager::DWalletMPCManager`] for processing.
+    ///
+    /// The service automatically terminates when an epoch switch occurs.
     pub async fn spawn(&mut self) {
-        'main: loop {
+        loop {
             match self.exit.has_changed() {
                 Ok(true) | Err(_) => {
                     break;
                 }
                 Ok(false) => (),
             };
-            tokio::time::sleep(tokio::time::Duration::from_millis(READ_INTERVAL_MILLIS)).await;
+            tokio::time::sleep(tokio::time::Duration::from_millis(READ_INTERVAL_MS)).await;
             let mut manager = self.epoch_store.get_dwallet_mpc_manager().await;
             let Ok(tables) = self.epoch_store.tables() else {
                 error!("Failed to load DB tables from epoch store");
-                continue 'main;
+                continue;
             };
             let Ok(completed_sessions) = self
                 .epoch_store
-                .load_dwallet_mpc_completed_sessions_from_round(self.last_read_narwhal_round + 1)
+                .load_dwallet_mpc_completed_sessions_from_round(self.last_read_consensus_round + 1)
                 .await
             else {
                 error!("Failed to load DWallet MPC events from the local DB");
-                continue 'main;
+                continue;
             };
             for session_id in completed_sessions {
                 manager.mpc_sessions.get_mut(&session_id).map(|session| {
@@ -69,21 +73,21 @@ impl DWalletMPCService {
             }
             let Ok(events) = self
                 .epoch_store
-                .load_dwallet_mpc_events_from_round(self.last_read_narwhal_round + 1)
+                .load_dwallet_mpc_events_from_round(self.last_read_consensus_round + 1)
                 .await
             else {
                 error!("Failed to load DWallet MPC events from the local DB");
-                continue 'main;
+                continue;
             };
             for event in events {
                 manager.handle_dwallet_db_event(event).await;
             }
             let new_dwallet_messages_iter = tables
                 .dwallet_mpc_messages
-                .iter_with_bounds(Some(self.last_read_narwhal_round + 1), None);
+                .iter_with_bounds(Some(self.last_read_consensus_round + 1), None);
             let mut new_messages = vec![];
             for (round, messages) in new_dwallet_messages_iter {
-                self.last_read_narwhal_round = round;
+                self.last_read_consensus_round = round;
                 new_messages.extend(messages);
             }
             for message in new_messages {

--- a/crates/pera-core/src/dwallet_mpc/malicious_handler.rs
+++ b/crates/pera-core/src/dwallet_mpc/malicious_handler.rs
@@ -6,6 +6,7 @@ use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::dwallet_mpc::authority_name_to_party_id;
 use group::PartyID;
 use mpc::Weight;
+use narwhal_config::Export;
 use pera_types::base_types::{AuthorityName, ObjectID};
 use pera_types::committee::StakeUnit;
 use pera_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
@@ -118,9 +119,9 @@ impl MaliciousHandler {
             .collect::<DwalletMPCResult<HashSet<_>>>()?)
     }
 
-    /// Reports a malicious actor that is disrupting the MPC process.
+    /// Reports malicious actors that are disrupting the MPC process.
     /// Reported by the validator itself.
-    pub(crate) fn report_malicious_internal(&mut self, authority: AuthorityName) {
-        self.malicious_actors.insert(authority);
+    pub(crate) fn report_malicious_actors(&mut self, authorities: &[AuthorityName]) {
+        self.malicious_actors.extend(authorities);
     }
 }

--- a/crates/pera-core/src/dwallet_mpc/mod.rs
+++ b/crates/pera-core/src/dwallet_mpc/mod.rs
@@ -24,13 +24,14 @@ use pera_types::base_types::{EpochId, ObjectID};
 use pera_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use pera_types::event::Event;
 use pera_types::messages_dwallet_mpc::{
-    MPCInitProtocolInfo, SessionInfo, SignSessionData, StartDKGSecondRoundEvent,
+    MPCProtocolInitData, SessionInfo, SingleSignSessionData, StartDKGSecondRoundEvent,
     StartEncryptedShareVerificationEvent, StartEncryptionKeyVerificationEvent,
 };
 use serde::de::DeserializeOwned;
 use std::collections::{HashMap, HashSet};
 
 pub mod batches_manager;
+mod cryptographic_computations_orchestrator;
 mod dkg;
 pub mod dwallet_mpc_service;
 mod encrypt_user_share;
@@ -147,7 +148,7 @@ fn start_encrypted_share_verification_session_info(
         flow_session_id: deserialized_event.session_id.bytes,
         session_id: deserialized_event.session_id.bytes,
         initiating_user_address: Default::default(),
-        mpc_round: MPCInitProtocolInfo::EncryptedShareVerification(deserialized_event),
+        mpc_round: MPCProtocolInitData::EncryptedShareVerification(deserialized_event),
     }
 }
 
@@ -158,7 +159,7 @@ fn start_encryption_key_verification_session_info(
         flow_session_id: deserialized_event.session_id.bytes,
         session_id: deserialized_event.session_id.bytes,
         initiating_user_address: Default::default(),
-        mpc_round: MPCInitProtocolInfo::EncryptionKeyVerification(deserialized_event),
+        mpc_round: MPCProtocolInitData::EncryptionKeyVerification(deserialized_event),
     }
 }
 
@@ -181,7 +182,7 @@ fn dkg_second_party_session_info(
         flow_session_id: deserialized_event.first_round_session_id.bytes,
         session_id: ObjectID::from(deserialized_event.session_id),
         initiating_user_address: deserialized_event.initiator,
-        mpc_round: MPCInitProtocolInfo::DKGSecond(
+        mpc_round: MPCProtocolInitData::DKGSecond(
             deserialized_event.clone(),
             dwallet_network_key_version,
         ),
@@ -199,7 +200,7 @@ fn dkg_first_party_session_info(deserialized_event: StartDKGFirstRoundEvent) -> 
         flow_session_id: deserialized_event.session_id.bytes,
         session_id: deserialized_event.session_id.bytes,
         initiating_user_address: deserialized_event.initiator,
-        mpc_round: MPCInitProtocolInfo::DKGFirst,
+        mpc_round: MPCProtocolInitData::DKGFirst,
     }
 }
 
@@ -222,7 +223,7 @@ fn presign_first_party_session_info(
         flow_session_id: deserialized_event.session_id.bytes,
         session_id: deserialized_event.session_id.bytes,
         initiating_user_address: deserialized_event.initiator,
-        mpc_round: MPCInitProtocolInfo::PresignFirst(
+        mpc_round: MPCProtocolInitData::PresignFirst(
             deserialized_event.dwallet_id.bytes,
             deserialized_event.dkg_output,
             deserialized_event.batch_session_id.bytes,
@@ -251,7 +252,7 @@ fn presign_second_party_session_info(
         flow_session_id: deserialized_event.first_round_session_id.bytes,
         session_id: deserialized_event.session_id.bytes,
         initiating_user_address: deserialized_event.initiator,
-        mpc_round: MPCInitProtocolInfo::PresignSecond(
+        mpc_round: MPCProtocolInitData::PresignSecond(
             deserialized_event.dwallet_id.bytes,
             deserialized_event.first_round_output.clone(),
             deserialized_event.batch_session_id.bytes,
@@ -290,7 +291,7 @@ fn sign_party_session_info(
         flow_session_id: deserialized_event.presign_session_id.bytes,
         session_id: deserialized_event.session_id.bytes,
         initiating_user_address: deserialized_event.initiator,
-        mpc_round: MPCInitProtocolInfo::Sign(SignSessionData {
+        mpc_round: MPCProtocolInitData::Sign(SingleSignSessionData {
             batch_session_id: deserialized_event.batched_session_id.bytes,
             message: deserialized_event.hashed_message.clone(),
             dwallet_id: deserialized_event.dwallet_id.bytes,
@@ -305,7 +306,7 @@ fn batched_sign_session_info(deserialized_event: &StartBatchedSignEvent) -> Sess
         flow_session_id: deserialized_event.session_id.bytes,
         session_id: deserialized_event.session_id.bytes,
         initiating_user_address: deserialized_event.initiator,
-        mpc_round: MPCInitProtocolInfo::BatchedSign(deserialized_event.hashed_messages.clone()),
+        mpc_round: MPCProtocolInitData::BatchedSign(deserialized_event.hashed_messages.clone()),
     }
 }
 
@@ -314,7 +315,7 @@ fn batched_presign_session_info(deserialized_event: &StartBatchedPresignEvent) -
         flow_session_id: deserialized_event.session_id.bytes,
         session_id: deserialized_event.session_id.bytes,
         initiating_user_address: deserialized_event.initiator,
-        mpc_round: MPCInitProtocolInfo::BatchedPresign(deserialized_event.batch_size),
+        mpc_round: MPCProtocolInitData::BatchedPresign(deserialized_event.batch_size),
     }
 }
 

--- a/crates/pera-core/src/dwallet_mpc/mod.rs
+++ b/crates/pera-core/src/dwallet_mpc/mod.rs
@@ -24,7 +24,7 @@ use pera_types::base_types::{EpochId, ObjectID};
 use pera_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use pera_types::event::Event;
 use pera_types::messages_dwallet_mpc::{
-    MPCInitProtocolInfo, SessionInfo, SignMessageData, StartDKGSecondRoundEvent,
+    MPCInitProtocolInfo, SessionInfo, SignSessionData, StartDKGSecondRoundEvent,
     StartEncryptedShareVerificationEvent, StartEncryptionKeyVerificationEvent,
 };
 use serde::de::DeserializeOwned;
@@ -290,10 +290,12 @@ fn sign_party_session_info(
         flow_session_id: deserialized_event.presign_session_id.bytes,
         session_id: deserialized_event.session_id.bytes,
         initiating_user_address: deserialized_event.initiator,
-        mpc_round: MPCInitProtocolInfo::Sign(SignMessageData {
+        mpc_round: MPCInitProtocolInfo::Sign(SignSessionData {
             batch_session_id: deserialized_event.batched_session_id.bytes,
             message: deserialized_event.hashed_message.clone(),
             dwallet_id: deserialized_event.dwallet_id.bytes,
+            dkg_output: deserialized_event.dkg_output.clone(),
+            network_key_version: deserialized_event.dwallet_mpc_network_key_version,
         }),
     }
 }

--- a/crates/pera-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/pera-core/src/dwallet_mpc/mpc_manager.rs
@@ -3,12 +3,16 @@ use crate::consensus_adapter::SubmitToConsensus;
 use pera_types::base_types::{AuthorityName, ObjectID};
 use pera_types::error::PeraResult;
 
+use crate::dwallet_mpc::cryptographic_computations_orchestrator::CryptographicComputationsOrchestrator;
 use crate::dwallet_mpc::malicious_handler::{MaliciousHandler, ReportStatus};
 use crate::dwallet_mpc::mpc_events::ValidatorDataForNetworkDKG;
 use crate::dwallet_mpc::mpc_outputs_verifier::DWalletMPCOutputsVerifier;
 use crate::dwallet_mpc::mpc_session::{AsyncProtocol, DWalletMPCSession};
 use crate::dwallet_mpc::network_dkg::DwalletMPCNetworkKeysStatus;
 use crate::dwallet_mpc::session_input_from_event;
+use crate::dwallet_mpc::sign::{
+    LAST_SIGN_ROUND_INDEX, SIGN_LAST_ROUND_COMPUTATION_CONSTANT_SECONDS,
+};
 use crate::dwallet_mpc::{authority_name_to_party_id, party_id_to_authority_name};
 use crate::epoch::randomness::SINGLETON_KEY;
 use class_groups::DecryptionKeyShare;
@@ -18,6 +22,7 @@ use dwallet_mpc_types::dwallet_mpc::{
 };
 use fastcrypto::hash::HashFunction;
 use fastcrypto::traits::ToFromBytes;
+use futures::future::err;
 use group::PartyID;
 use homomorphic_encryption::AdditivelyHomomorphicDecryptionKeyShare;
 use mpc::WeightedThresholdAccessStructure;
@@ -26,11 +31,12 @@ use pera_types::committee::{EpochId, StakeUnit};
 use pera_types::crypto::AuthorityPublicKeyBytes;
 use pera_types::crypto::DefaultHash;
 use pera_types::digests::Digest;
+use pera_types::digests::TransactionDigest;
 use pera_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use pera_types::event::Event;
 use pera_types::messages_consensus::{ConsensusTransaction, DWalletMPCMessage};
 use pera_types::messages_dwallet_mpc::{
-    DWalletMPCEvent, DWalletMPCLocalComputationMetadata, MPCInitProtocolInfo, MaliciousReport,
+    DWalletMPCEvent, DWalletMPCLocalComputationMetadata, MPCProtocolInitData, MaliciousReport,
     SessionInfo,
 };
 use rayon::prelude::*;
@@ -38,15 +44,12 @@ use serde::{Deserialize, Serialize};
 use shared_crypto::intent::HashingIntentScope;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Weak};
+use tokio::runtime::Handle;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::log::debug;
 use tracing::{error, info, warn};
 use twopc_mpc::sign::Protocol;
 use typed_store::Map;
-
-/// The number of logical cores validator's need to allocate for ongoing, non-cryptographic computations.
-/// Needed to understand how many sessions computations this validator can run in parallel.
-const MACHINE_CORS_FOR_NON_COMPUTATION: usize = 3;
 
 /// The [`DWalletMPCManager`] manages MPC sessions:
 /// — Keeping track of all MPC sessions,
@@ -70,24 +73,10 @@ pub struct DWalletMPCManager {
     epoch_id: EpochId,
     weighted_threshold_access_structure: WeightedThresholdAccessStructure,
     pub(crate) validators_data_for_network_dkg: HashMap<PartyID, ValidatorDataForNetworkDKG>,
-    /// A map of the pending cryptographic computation sessions.
-    /// This map is needed in order to remove a session that we received a quorum of messages for
-    /// its next round, so running the current, completed round is redundant.
-    pub(crate) pending_computation_map:
-        HashMap<DWalletMPCLocalComputationMetadata, DWalletMPCSession>,
-    /// The order of the [`pending_computation_map`]. Needed to process the computations in the order they were received.
-    pending_for_computation_order: VecDeque<DWalletMPCLocalComputationMetadata>,
-    /// The number of currently running cryptographic computations - i.e. computations we called [`rayon::spawn_fifo`] for,
-    /// but we didn't receive a completion message for.
-    pub(crate) currently_running_sessions_count: usize,
-    /// The number of logical CPUs available for cryptographic computations on the validator's machine.
-    available_cores_for_cryptographic_computations: usize,
-    /// A channel sender to notify the manager that a computation has been completed.
-    /// This is needed to decrease the [`currently_running_sessions_count`] when a computation is done.
-    completed_computation_channel_sender: UnboundedSender<()>,
     /// A set of all the authorities that behaved maliciously at least once during the epoch.
     /// Any message/output from these authorities will be ignored.
     malicious_handler: MaliciousHandler,
+    pub(crate) cryptographic_computations_orchestrator: CryptographicComputationsOrchestrator,
 }
 
 /// The messages that the [`DWalletMPCManager`] can receive & process asynchronously.
@@ -104,7 +93,8 @@ pub enum DWalletMPCDBMessage {
     /// reconfiguration process for the next epoch.
     StartLockNextEpochCommittee,
     /// A vote received from another validator to lock the next committee.
-    /// After receiving a quorum of those messages, a system TX to lock the next epoch's committee will get created.
+    /// After receiving a quorum of those messages, a system TX
+    /// to lock the next epoch's committee will get created.
     LockNextEpochCommitteeVote(AuthorityName),
     /// A validator's public key and proof for the network DKG protocol.
     /// Each validator's data is being emitted separately because the proof size is
@@ -115,9 +105,9 @@ pub enum DWalletMPCDBMessage {
     /// A message indicating that an MPC session has failed.
     /// The advance failed, and the session needs to be restarted or marked as failed.
     MPCSessionFailed(ObjectID),
-    /// A message to start process the cryptographic computations.
-    /// This message is being sent every five seconds by the DWallet MPC Service,
-    /// in order to skip redundant advancements that have already been completed by other validators.
+    /// A message to start processing the cryptographic computations.
+    /// This message is being sent every five seconds by the dWallet MPC Service,
+    /// to skip redundant advancements that have already been completed by other validators.
     PerformCryptographicComputations,
     /// A message indicating that a session failed due to malicious parties.
     /// We can receive new messages for this session with other validators,
@@ -134,16 +124,8 @@ impl DWalletMPCManager {
     ) -> DwalletMPCResult<Self> {
         let weighted_threshold_access_structure =
             epoch_store.get_weighted_threshold_access_structure()?;
-        let completed_computation_channel_sender =
-            Self::listen_for_completed_computations(&epoch_store);
-        let available_cores_for_computations: usize = std::thread::available_parallelism()
-            .map_err(|e| DwalletMPCError::FailedToGetAvailableParallelism)?
-            .into();
-        if !(available_cores_for_computations > MACHINE_CORS_FOR_NON_COMPUTATION) {
-            return Err(DwalletMPCError::InsufficientCPUCores);
-        }
-        let available_cores_for_cryptographic_computations =
-            available_cores_for_computations - MACHINE_CORS_FOR_NON_COMPUTATION;
+        let mpc_computations_orchestrator =
+            CryptographicComputationsOrchestrator::try_new(&epoch_store)?;
         Ok(Self {
             mpc_sessions: HashMap::new(),
             pending_sessions_queue: VecDeque::new(),
@@ -156,11 +138,7 @@ impl DWalletMPCManager {
             node_config,
             weighted_threshold_access_structure,
             validators_data_for_network_dkg: HashMap::new(),
-            pending_computation_map: HashMap::new(),
-            pending_for_computation_order: VecDeque::new(),
-            currently_running_sessions_count: 0,
-            available_cores_for_cryptographic_computations,
-            completed_computation_channel_sender,
+            cryptographic_computations_orchestrator: mpc_computations_orchestrator,
             malicious_handler: MaliciousHandler::new(
                 epoch_store.committee().quorum_threshold(),
                 epoch_store
@@ -405,7 +383,7 @@ impl DWalletMPCManager {
                 let is_valid_network_dkg_transaction =
                     matches!(
                         session.session_info.mpc_round,
-                        MPCInitProtocolInfo::NetworkDkg(..)
+                        MPCProtocolInitData::NetworkDkg(..)
                     ) && self.validators_data_for_network_dkg.len()
                         == self
                             .weighted_threshold_access_structure
@@ -429,43 +407,39 @@ impl DWalletMPCManager {
             })
             .collect();
 
-        for session in ready_to_advance.into_iter() {
-            if session.pending_quorum_for_highest_round_number > 0 {
-                self.pending_computation_map
-                    .remove(&DWalletMPCLocalComputationMetadata {
-                        session_id: session.session_info.session_id,
-                        crypto_round_number: session.pending_quorum_for_highest_round_number - 1,
-                    });
-            }
-            let session_next_round_metadata = DWalletMPCLocalComputationMetadata {
-                session_id: session.session_info.session_id,
-                crypto_round_number: session.pending_quorum_for_highest_round_number,
-            };
-            self.pending_computation_map
-                .insert(session_next_round_metadata.clone(), session.clone());
-            self.pending_for_computation_order
-                .push_back(session_next_round_metadata);
-        }
+        self.cryptographic_computations_orchestrator
+            .insert_ready_sessions(ready_to_advance);
         Ok(())
     }
 
-    fn perform_cryptographic_computation(&mut self) {
-        while self.currently_running_sessions_count
-            < self.available_cores_for_cryptographic_computations
+    /// Spawns all ready MPC cryptographic computations using Rayon.
+    /// If no local CPUs are available, computations will execute as CPUs are freed.
+    pub(crate) fn perform_cryptographic_computation(&mut self) {
+        while self
+            .cryptographic_computations_orchestrator
+            .currently_running_sessions_count
+            < self
+                .cryptographic_computations_orchestrator
+                .available_cores_for_cryptographic_computations
         {
-            let Some(oldest_computation_metadata) = self.pending_for_computation_order.pop_front()
+            let Some(oldest_computation_metadata) = self
+                .cryptographic_computations_orchestrator
+                .pending_for_computation_order
+                .pop_front()
             else {
-                break;
+                return;
             };
             let Some(session) = self
+                .cryptographic_computations_orchestrator
                 .pending_computation_map
                 .remove(&oldest_computation_metadata)
             else {
                 return;
             };
-            self.currently_running_sessions_count += 1;
+            self.cryptographic_computations_orchestrator
+                .currently_running_sessions_count += 1;
             if let Err(err) = self.spawn_session(&session) {
-                error!("Failed to spawn session with err: {:?}", err);
+                error!("failed to spawn session with err: {:?}", err);
                 return;
             }
         }
@@ -482,18 +456,74 @@ impl DWalletMPCManager {
         {
             return Ok(());
         }
+        // Hook the tokio thread pool to the rayon thread pool.
         let handle = tokio::runtime::Handle::current();
         let session = session.clone();
-        let finished_computation_sender = self.completed_computation_channel_sender.clone();
-        rayon::spawn_fifo(move || {
-            if let Err(err) = session.advance(&handle) {
-                error!("Failed to advance session with error: {:?}", err);
-            }
-            if let Err(err) = finished_computation_sender.send(()) {
+        let finished_computation_sender = self
+            .cryptographic_computations_orchestrator
+            .completed_computation_channel_sender
+            .clone();
+        if matches!(
+            session.session_info.mpc_round,
+            MPCProtocolInitData::Sign(..)
+        ) && session.pending_quorum_for_highest_round_number == LAST_SIGN_ROUND_INDEX
+        {
+            self.spawn_aggregated_sign(session_id, handle, session, finished_computation_sender)?;
+        } else {
+            rayon::spawn_fifo(move || {
+                if let Err(err) = session.advance(&handle) {
+                    error!("failed to advance session with error: {:?}", err);
+                }
+                if let Err(err) = finished_computation_sender.send(()) {
+                    error!(
+                        "Failed to send a finished computation message with error: {:?}",
+                        err
+                    );
+                }
+            });
+        }
+        Ok(())
+    }
+
+    fn spawn_aggregated_sign(
+        &self,
+        session_id: ObjectID,
+        handle: Handle,
+        session: DWalletMPCSession,
+        finished_computation_sender: UnboundedSender<()>,
+    ) -> DwalletMPCResult<()> {
+        let sign_last_step_delay =
+            self.calculate_last_sign_step_validator_delay(&session.session_info)?;
+        let epoch_store = self.epoch_store()?;
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_secs(
+                sign_last_step_delay as u64,
+            ))
+            .await;
+            let manager = epoch_store.get_dwallet_mpc_manager().await;
+            let Some(session) = manager.mpc_sessions.get(&session_id) else {
                 error!(
-                    "Failed to send finished computation message with error: {:?}",
-                    err
+                    "failed to get session when checking if sign last round should get executed"
                 );
+                return;
+            };
+            if session.status == MPCSessionStatus::Active {
+                info!(
+                    "running last sign cryptographic step for session_id: {:?}",
+                    session_id
+                );
+                let session = session.clone();
+                rayon::spawn_fifo(move || {
+                    if let Err(err) = session.advance(&handle) {
+                        error!("failed to advance session with error: {:?}", err);
+                    }
+                    if let Err(err) = finished_computation_sender.send(()) {
+                        error!(
+                            "Failed to send a finished computation message with error: {:?}",
+                            err
+                        );
+                    }
+                });
             }
         });
         Ok(())
@@ -507,7 +537,7 @@ impl DWalletMPCManager {
         public_output: MPCPublicOutput,
         private_output: MPCPrivateOutput,
     ) -> DwalletMPCResult<()> {
-        if let MPCInitProtocolInfo::NetworkDkg(key_type, _) = session_info.mpc_round {
+        if let MPCProtocolInitData::NetworkDkg(key_type, _) = session_info.mpc_round {
             let epoch_store = self.epoch_store()?;
             let network_keys = epoch_store
                 .dwallet_mpc_network_keys
@@ -531,6 +561,27 @@ impl DWalletMPCManager {
             .ok_or(DwalletMPCError::EpochEnded(self.epoch_id))
     }
 
+    /// Deterministically decides by the session ID how long this validator should wait before
+    /// running the last step of the sign protocol.
+    /// If while waiting, the validator receives a valid signature for this session,
+    /// it will not run the last step in the sign protocol, and save computation resources.
+    fn calculate_last_sign_step_validator_delay(
+        &self,
+        session_info: &SessionInfo,
+    ) -> DwalletMPCResult<usize> {
+        let session_id_as_32_bytes: [u8; 32] = session_info.session_id.into_bytes();
+        let positions = &self
+            .epoch_store()?
+            .committee()
+            .shuffle_by_stake_from_tx_digest(&TransactionDigest::new(session_id_as_32_bytes));
+        let authority_name = &self.epoch_store()?.name;
+        let position = positions
+            .iter()
+            .position(|&x| x == *authority_name)
+            .ok_or(DwalletMPCError::InvalidMPCPartyType)?;
+        Ok(SIGN_LAST_ROUND_COMPUTATION_CONSTANT_SECONDS * position)
+    }
+
     /// Handles a message by forwarding it to the relevant MPC session.
     /// If the session does not exist, punish the sender.
     pub(crate) fn handle_message(&mut self, message: DWalletMPCMessage) -> DwalletMPCResult<()> {
@@ -549,7 +600,7 @@ impl DWalletMPCManager {
                     message.session_id
                 );
                 self.malicious_handler
-                    .report_malicious_internal(message.authority);
+                    .report_malicious_actors(&vec![message.authority]);
                 return Ok(());
             }
         };
@@ -576,10 +627,16 @@ impl DWalletMPCManager {
             malicious_parties_names
         );
 
-        malicious_parties_names
-            .into_iter()
-            .for_each(|party| self.malicious_handler.report_malicious_internal(party));
+        self.malicious_handler
+            .report_malicious_actors(&malicious_parties_names);
         Ok(())
+    }
+
+    /// Flags the given authorities as malicious.
+    /// Future messages from these authorities will be ignored.
+    pub(crate) fn flag_authorities_as_malicious(&mut self, malicious_parties: &[AuthorityName]) {
+        self.malicious_handler
+            .report_malicious_actors(&malicious_parties);
     }
 
     /// Spawns a new MPC session if the number of active sessions is below the limit.
@@ -602,6 +659,7 @@ impl DWalletMPCManager {
             "Received start MPC flow event for session ID {:?}",
             session_info.session_id
         );
+
         let mut new_session = DWalletMPCSession::new(
             self.epoch_store.clone(),
             self.consensus_adapter.clone(),
@@ -612,7 +670,7 @@ impl DWalletMPCManager {
             self.party_id,
             self.weighted_threshold_access_structure.clone(),
             match session_info.mpc_round {
-                MPCInitProtocolInfo::NetworkDkg(..) => HashMap::new(),
+                MPCProtocolInitData::NetworkDkg(..) => HashMap::new(),
                 _ => self.get_decryption_key_shares(
                     DWalletMPCNetworkKeyScheme::Secp256k1,
                     Some(self.network_key_version(DWalletMPCNetworkKeyScheme::Secp256k1)? as usize),
@@ -650,29 +708,5 @@ impl DWalletMPCManager {
             .get()
             .ok_or(DwalletMPCError::MissingDwalletMPCDecryptionKeyShares)?
             .key_version(key_type)
-    }
-
-    fn listen_for_completed_computations(
-        epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> UnboundedSender<()> {
-        let (completed_computation_channel_sender, mut completed_computation_channel_receiver) =
-            tokio::sync::mpsc::unbounded_channel();
-        let epoch_store_for_channel = epoch_store.clone();
-        tokio::spawn(async move {
-            loop {
-                match completed_computation_channel_receiver.recv().await {
-                    None => {
-                        break;
-                    }
-                    Some(_) => {
-                        epoch_store_for_channel
-                            .get_dwallet_mpc_manager()
-                            .await
-                            .currently_running_sessions_count -= 1;
-                    }
-                }
-            }
-        });
-        completed_computation_channel_sender
     }
 }

--- a/crates/pera-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/pera-core/src/dwallet_mpc/mpc_manager.rs
@@ -368,11 +368,13 @@ impl DWalletMPCManager {
             .collect();
 
         for session in ready_to_advance.into_iter() {
-            self.pending_computation_map
-                .remove(&DWalletMPCLocalComputationMetadata {
-                    session_id: session.session_info.session_id,
-                    crypto_round_number: session.round_number - 1,
-                });
+            if session.round_number > 0 {
+                self.pending_computation_map
+                    .remove(&DWalletMPCLocalComputationMetadata {
+                        session_id: session.session_info.session_id,
+                        crypto_round_number: session.round_number - 1,
+                    });
+            }
             let session_next_round_metadata = DWalletMPCLocalComputationMetadata {
                 session_id: session.session_info.session_id,
                 crypto_round_number: session.round_number,

--- a/crates/pera-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/pera-core/src/dwallet_mpc/mpc_manager.rs
@@ -30,7 +30,8 @@ use pera_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use pera_types::event::Event;
 use pera_types::messages_consensus::{ConsensusTransaction, DWalletMPCMessage};
 use pera_types::messages_dwallet_mpc::{
-    DWalletMPCEvent, DWalletMPCLocalComputationMetadata, MPCInitProtocolInfo, MaliciousReport, SessionInfo,
+    DWalletMPCEvent, DWalletMPCLocalComputationMetadata, MPCInitProtocolInfo, MaliciousReport,
+    SessionInfo,
 };
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -241,11 +242,11 @@ impl DWalletMPCManager {
                 if let Some(session) = self.mpc_sessions.get_mut(&report.session_id) {
                     // For every advance we increase the round number by 1,
                     // so to re-run the same round we decrease it by 1.
-                    session.round_number -= 1;
+                    session.pending_quorum_for_highest_round_number -= 1;
                     // Remove malicious parties from the session messages.
                     let round_messages = session
                         .pending_messages
-                        .get_mut(session.round_number)
+                        .get_mut(session.pending_quorum_for_highest_round_number)
                         .ok_or(DwalletMPCError::MPCSessionNotFound {
                             session_id: report.session_id,
                         })?;

--- a/crates/pera-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/pera-core/src/dwallet_mpc/mpc_manager.rs
@@ -37,7 +37,7 @@ use shared_crypto::intent::HashingIntentScope;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Weak};
 use tokio::sync::mpsc::UnboundedSender;
-use tracing::log::{debug};
+use tracing::log::debug;
 use tracing::{error, info, warn};
 use twopc_mpc::sign::Protocol;
 use typed_store::Map;

--- a/crates/pera-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/pera-core/src/dwallet_mpc/mpc_manager.rs
@@ -138,10 +138,6 @@ impl DWalletMPCManager {
         }
         let available_cores_for_cryptographic_computations =
             available_cores_for_computations - MACHINE_CORS_FOR_NON_COMPUTATION;
-        error!(
-            "Available cores for cryptographic computations: {}",
-            available_cores_for_cryptographic_computations
-        );
         Ok(Self {
             mpc_sessions: HashMap::new(),
             pending_sessions_queue: VecDeque::new(),

--- a/crates/pera-core/src/dwallet_mpc/mpc_outputs_verifier.rs
+++ b/crates/pera-core/src/dwallet_mpc/mpc_outputs_verifier.rs
@@ -14,7 +14,7 @@ use narwhal_types::Round;
 use pera_types::base_types::{AuthorityName, EpochId, ObjectID};
 use pera_types::committee::StakeUnit;
 use pera_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
-use pera_types::messages_dwallet_mpc::{MPCInitProtocolInfo, SessionInfo, SignSessionData};
+use pera_types::messages_dwallet_mpc::{MPCProtocolInitData, SessionInfo, SingleSignSessionData};
 use std::cmp::PartialEq;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Weak};
@@ -39,11 +39,12 @@ pub struct DWalletMPCOutputsVerifier {
     // todo(zeev): why is it here?
     pub completed_locking_next_committee: bool,
     voted_to_lock_committee: HashSet<AuthorityName>,
-    /// The latest narwhal round that was processed.
-    /// Used to check if there's a need to perform a state sync -
-    /// if the latest_processed_dwallet_round is behind the currently processed round by more than one,
+    /// The latest consensus round that was processed.
+    /// Used to check if there's a need to perform a state sync —
+    /// if the `latest_processed_dwallet_round` is behind
+    /// the currently processed round by more than one,
     /// a state sync should be performed.
-    pub(crate) last_processed_round: Round,
+    pub(crate) last_processed_consensus_round: Round,
     epoch_store: Weak<AuthorityPerEpochStore>,
     epoch_id: EpochId,
 }
@@ -94,7 +95,7 @@ impl DWalletMPCOutputsVerifier {
                 .collect(),
             completed_locking_next_committee: false,
             voted_to_lock_committee: HashSet::new(),
-            last_processed_round: 0,
+            last_processed_consensus_round: 0,
             epoch_id: epoch_store.epoch(),
         }
     }
@@ -141,7 +142,7 @@ impl DWalletMPCOutputsVerifier {
                 malicious_actors: vec![],
             });
         }
-        if let MPCInitProtocolInfo::Sign(sign_session_data) = &session_info.mpc_round {
+        if let MPCProtocolInitData::Sign(sign_session_data) = &session_info.mpc_round {
             return match Self::verify_signature(&epoch_store, sign_session_data, output) {
                 Ok(res) => {
                     session.current_result = OutputResult::AlreadyCommitted;
@@ -223,7 +224,7 @@ impl DWalletMPCOutputsVerifier {
 
     fn verify_signature(
         epoch_store: &Arc<AuthorityPerEpochStore>,
-        sign_session_data: &SignSessionData,
+        sign_session_data: &SingleSignSessionData,
         signature: &MPCPublicOutput,
     ) -> DwalletMPCResult<OutputVerificationResult> {
         let sign_output = bcs::from_bytes::<<SignFirstParty as Party>::PublicOutput>(&signature)?;
@@ -245,19 +246,23 @@ impl DWalletMPCOutputsVerifier {
             dkg_output,
             &protocol_public_parameters.as_ref().group_public_parameters,
         )
-        .map_err(|_| {
-            DwalletMPCError::ClassGroupsError("Failed to create public key".to_string())
+        .map_err(|e| {
+            DwalletMPCError::ClassGroupsError(format!(
+                "{}{}",
+                "Failed to create public key: ".to_string(),
+                e.to_string()
+            ))
         })?;
 
-        if verify_signature(
+        if let Err(err) = verify_signature(
             sign_output.0,
             sign_output.1,
             bcs::from_bytes(&sign_session_data.message)?,
             dwallet_public_key,
-        )
-        .is_err()
-        {
-            return Err(DwalletMPCError::SignatureVerificationFailed);
+        ) {
+            return Err(DwalletMPCError::SignatureVerificationFailed(
+                err.to_string(),
+            ));
         }
         Ok(OutputVerificationResult {
             result: OutputResult::Valid,

--- a/crates/pera-core/src/dwallet_mpc/mpc_outputs_verifier.rs
+++ b/crates/pera-core/src/dwallet_mpc/mpc_outputs_verifier.rs
@@ -5,13 +5,23 @@
 //! Any validator that voted for a different output is considered malicious.
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
-use dwallet_mpc_types::dwallet_mpc::MPCPublicOutput;
+use crate::dwallet_mpc::dkg::DKGSecondParty;
+use crate::dwallet_mpc::sign::SignFirstParty;
+use dwallet_mpc_types::dwallet_mpc::{DWalletMPCNetworkKeyScheme, MPCPublicOutput};
+use group::GroupElement;
+use mpc::Party;
 use narwhal_types::Round;
-use pera_types::base_types::{AuthorityName, ObjectID};
+use pera_types::base_types::{AuthorityName, EpochId, ObjectID};
 use pera_types::committee::StakeUnit;
-use pera_types::messages_dwallet_mpc::SessionInfo;
+use pera_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
+use pera_types::messages_dwallet_mpc::{MPCInitProtocolInfo, SessionInfo, SignSessionData};
 use std::cmp::PartialEq;
 use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Weak};
+use tracing::error;
+use tracing::log::warn;
+use twopc_mpc::sign::verify_signature;
+use twopc_mpc::{secp256k1, ProtocolPublicParameters};
 
 /// Verify the DWallet MPC outputs.
 ///
@@ -34,6 +44,8 @@ pub struct DWalletMPCOutputsVerifier {
     /// if the latest_processed_dwallet_round is behind the currently processed round by more than one,
     /// a state sync should be performed.
     pub(crate) last_processed_round: Round,
+    epoch_store: Weak<AuthorityPerEpochStore>,
+    epoch_id: EpochId,
 }
 
 /// The data needed to manage the outputs of an MPC session.
@@ -69,8 +81,9 @@ pub struct OutputVerificationResult {
 }
 
 impl DWalletMPCOutputsVerifier {
-    pub fn new(epoch_store: &AuthorityPerEpochStore) -> Self {
+    pub fn new(epoch_store: &Arc<AuthorityPerEpochStore>) -> Self {
         DWalletMPCOutputsVerifier {
+            epoch_store: Arc::downgrade(&epoch_store),
             quorum_threshold: epoch_store.committee().quorum_threshold(),
             mpc_sessions_outputs: HashMap::new(),
             weighted_parties: epoch_store
@@ -82,6 +95,7 @@ impl DWalletMPCOutputsVerifier {
             completed_locking_next_committee: false,
             voted_to_lock_committee: HashSet::new(),
             last_processed_round: 0,
+            epoch_id: epoch_store.epoch(),
         }
     }
 
@@ -112,7 +126,8 @@ impl DWalletMPCOutputsVerifier {
         output: &Vec<u8>,
         session_info: &SessionInfo,
         origin_authority: AuthorityName,
-    ) -> anyhow::Result<OutputVerificationResult> {
+    ) -> DwalletMPCResult<OutputVerificationResult> {
+        let epoch_store = self.epoch_store()?;
         let Some(ref mut session) = self.mpc_sessions_outputs.get_mut(&session_info.session_id)
         else {
             return Ok(OutputVerificationResult {
@@ -125,6 +140,28 @@ impl DWalletMPCOutputsVerifier {
                 result: OutputResult::Duplicate,
                 malicious_actors: vec![],
             });
+        }
+        if let MPCInitProtocolInfo::Sign(sign_session_data) = &session_info.mpc_round {
+            return match Self::verify_signature(&epoch_store, sign_session_data, output) {
+                Ok(res) => {
+                    session.current_result = OutputResult::AlreadyCommitted;
+                    Ok(OutputVerificationResult {
+                        result: OutputResult::Valid,
+                        malicious_actors: res.malicious_actors,
+                    })
+                }
+                Err(err) => {
+                    // TODO (#549): Handle malicious behavior in aggregated sign flow
+                    error!(
+                        "received an invalid signature: {:?} for session: {:?}",
+                        err, session_info.session_id
+                    );
+                    Ok(OutputVerificationResult {
+                        result: OutputResult::Malicious,
+                        malicious_actors: vec![origin_authority],
+                    })
+                }
+            };
         }
         // Sent more than once.
         if session
@@ -174,6 +211,56 @@ impl DWalletMPCOutputsVerifier {
 
         Ok(OutputVerificationResult {
             result: OutputResult::NotEnoughVotes,
+            malicious_actors: vec![],
+        })
+    }
+
+    fn epoch_store(&self) -> DwalletMPCResult<Arc<AuthorityPerEpochStore>> {
+        self.epoch_store
+            .upgrade()
+            .ok_or(DwalletMPCError::EpochEnded(self.epoch_id))
+    }
+
+    fn verify_signature(
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+        sign_session_data: &SignSessionData,
+        signature: &MPCPublicOutput,
+    ) -> DwalletMPCResult<OutputVerificationResult> {
+        let sign_output = bcs::from_bytes::<<SignFirstParty as Party>::PublicOutput>(&signature)?;
+        let dkg_output = bcs::from_bytes::<<DKGSecondParty as Party>::PublicOutput>(
+            &sign_session_data.dkg_output,
+        )?
+        .public_key;
+        let protocol_public_parameters = epoch_store
+            .dwallet_mpc_network_keys
+            .get()
+            .ok_or(DwalletMPCError::MissingDwalletMPCDecryptionKeyShares)?
+            .get_protocol_public_parameters(
+                DWalletMPCNetworkKeyScheme::Secp256k1,
+                sign_session_data.network_key_version,
+            )?;
+        let protocol_public_parameters: secp256k1::class_groups::ProtocolPublicParameters =
+            bcs::from_bytes(&protocol_public_parameters)?;
+        let dwallet_public_key = secp256k1::GroupElement::new(
+            dkg_output,
+            &protocol_public_parameters.as_ref().group_public_parameters,
+        )
+        .map_err(|_| {
+            DwalletMPCError::ClassGroupsError("Failed to create public key".to_string())
+        })?;
+
+        if verify_signature(
+            sign_output.0,
+            sign_output.1,
+            bcs::from_bytes(&sign_session_data.message)?,
+            dwallet_public_key,
+        )
+        .is_err()
+        {
+            return Err(DwalletMPCError::SignatureVerificationFailed);
+        }
+        Ok(OutputVerificationResult {
+            result: OutputResult::Valid,
             malicious_actors: vec![],
         })
     }

--- a/crates/pera-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/pera-core/src/dwallet_mpc/mpc_session.rs
@@ -291,7 +291,7 @@ impl DWalletMPCSession {
             self.epoch_store()?.name,
             message,
             self.session_info.session_id.clone(),
-            self.round_number,
+            self.round_number + 1,
         ))
     }
 

--- a/crates/pera-core/src/dwallet_mpc/network_dkg.rs
+++ b/crates/pera-core/src/dwallet_mpc/network_dkg.rs
@@ -22,7 +22,7 @@ use group::{ristretto, secp256k1, PartyID};
 use homomorphic_encryption::AdditivelyHomomorphicDecryptionKeyShare;
 use mpc::{AsynchronousRoundResult, WeightedThresholdAccessStructure};
 use pera_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
-use pera_types::messages_dwallet_mpc::{MPCInitProtocolInfo, SessionInfo};
+use pera_types::messages_dwallet_mpc::{MPCProtocolInitData, SessionInfo};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 use twopc_mpc::secp256k1::class_groups::{
@@ -536,7 +536,7 @@ fn dkg_secp256k1_session_info(deserialized_event: StartNetworkDKGEvent) -> Sessi
         flow_session_id: deserialized_event.session_id.bytes,
         session_id: deserialized_event.session_id.bytes,
         initiating_user_address: Default::default(),
-        mpc_round: MPCInitProtocolInfo::NetworkDkg(DWalletMPCNetworkKeyScheme::Secp256k1, None),
+        mpc_round: MPCProtocolInitData::NetworkDkg(DWalletMPCNetworkKeyScheme::Secp256k1, None),
     }
 }
 
@@ -545,7 +545,7 @@ fn dkg_ristretto_session_info(deserialized_event: StartNetworkDKGEvent) -> Sessi
         flow_session_id: deserialized_event.session_id.bytes,
         session_id: deserialized_event.session_id.bytes,
         initiating_user_address: Default::default(),
-        mpc_round: MPCInitProtocolInfo::NetworkDkg(DWalletMPCNetworkKeyScheme::Ristretto, None),
+        mpc_round: MPCProtocolInitData::NetworkDkg(DWalletMPCNetworkKeyScheme::Ristretto, None),
     }
 }
 

--- a/crates/pera-core/src/dwallet_mpc/network_dkg.rs
+++ b/crates/pera-core/src/dwallet_mpc/network_dkg.rs
@@ -22,7 +22,7 @@ use group::{ristretto, secp256k1, PartyID};
 use homomorphic_encryption::AdditivelyHomomorphicDecryptionKeyShare;
 use mpc::{AsynchronousRoundResult, WeightedThresholdAccessStructure};
 use pera_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
-use pera_types::messages_dwallet_mpc::{MPCRound, SessionInfo};
+use pera_types::messages_dwallet_mpc::{MPCInitProtocolInfo, SessionInfo};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 use twopc_mpc::secp256k1::class_groups::{
@@ -536,7 +536,7 @@ fn dkg_secp256k1_session_info(deserialized_event: StartNetworkDKGEvent) -> Sessi
         flow_session_id: deserialized_event.session_id.bytes,
         session_id: deserialized_event.session_id.bytes,
         initiating_user_address: Default::default(),
-        mpc_round: MPCRound::NetworkDkg(DWalletMPCNetworkKeyScheme::Secp256k1, None),
+        mpc_round: MPCInitProtocolInfo::NetworkDkg(DWalletMPCNetworkKeyScheme::Secp256k1, None),
     }
 }
 
@@ -545,7 +545,7 @@ fn dkg_ristretto_session_info(deserialized_event: StartNetworkDKGEvent) -> Sessi
         flow_session_id: deserialized_event.session_id.bytes,
         session_id: deserialized_event.session_id.bytes,
         initiating_user_address: Default::default(),
-        mpc_round: MPCRound::NetworkDkg(DWalletMPCNetworkKeyScheme::Ristretto, None),
+        mpc_round: MPCInitProtocolInfo::NetworkDkg(DWalletMPCNetworkKeyScheme::Ristretto, None),
     }
 }
 

--- a/crates/pera-core/src/dwallet_mpc/sign.rs
+++ b/crates/pera-core/src/dwallet_mpc/sign.rs
@@ -6,6 +6,16 @@ use dwallet_mpc_types::dwallet_mpc::{MPCPublicInput, MPCPublicOutput};
 use pera_types::dwallet_mpc_error::DwalletMPCResult;
 use twopc_mpc::dkg::Protocol;
 
+/// The index of the last sign cryptographic round.
+/// Needed to be known in advance as this cryptographic step should ideally get computed only once
+/// by the `sign aggregation` protocol.
+pub(crate) const LAST_SIGN_ROUND_INDEX: usize = 1;
+/// The time a validator waits for each other validator to produce the result of the last sign
+/// computation round.
+/// Used to determine how long a validator should wait before running the final step of the sign
+/// MPC flow.
+pub(crate) const SIGN_LAST_ROUND_COMPUTATION_CONSTANT_SECONDS: usize = 30;
+
 pub(super) type SignFirstParty =
     <AsyncProtocol as twopc_mpc::sign::Protocol>::SignDecentralizedParty;
 pub(super) type SignPublicInput =

--- a/crates/pera-indexer/src/handlers/committer.rs
+++ b/crates/pera-indexer/src/handlers/committer.rs
@@ -170,7 +170,7 @@ async fn commit_checkpoints<S>(
             .advance_epoch(epoch_data)
             .await
             .tap_err(|e| {
-                error!("Failed to advance epoch with error: {}", e.to_string());
+                error!("failed to advance epoch with error: {}", e.to_string());
             })
             .expect("Advancing epochs in DB should not fail.");
         metrics.total_epoch_committed.inc();

--- a/crates/pera-types/src/dwallet_mpc_error.rs
+++ b/crates/pera-types/src/dwallet_mpc_error.rs
@@ -105,6 +105,9 @@ pub enum DwalletMPCError {
     #[error("failed to read the network decryption key shares")]
     DwalletMPCNetworkKeysNotFound,
 
+    #[error("failed to verify signature")]
+    SignatureVerificationFailed,
+
     #[error("failed to get available parallelism")]
     FailedToGetAvailableParallelism,
 

--- a/crates/pera-types/src/dwallet_mpc_error.rs
+++ b/crates/pera-types/src/dwallet_mpc_error.rs
@@ -105,13 +105,13 @@ pub enum DwalletMPCError {
     #[error("failed to read the network decryption key shares")]
     DwalletMPCNetworkKeysNotFound,
 
-    #[error("failed to verify signature")]
-    SignatureVerificationFailed,
+    #[error("failed to verify signature: {0}")]
+    SignatureVerificationFailed(String),
 
-    #[error("failed to get available parallelism")]
-    FailedToGetAvailableParallelism,
+    #[error("failed to get available parallelism: {0}")]
+    FailedToGetAvailableParallelism(String),
 
-    #[error("local machine has insufficient CPU cores to run a node")]
+    #[error("the local machine has insufficient CPU cores to run a node")]
     InsufficientCPUCores,
 }
 

--- a/crates/pera-types/src/messages_dwallet_mpc.rs
+++ b/crates/pera-types/src/messages_dwallet_mpc.rs
@@ -33,7 +33,7 @@ pub enum MPCInitProtocolInfo {
     /// the Presign first round output, and the batch session ID.
     PresignSecond(ObjectID, MPCPublicOutput, ObjectID),
     /// The first and only round of the Sign protocol.
-    Sign(SignMessageData),
+    Sign(SignSessionData),
     /// A batched sign session, contains the list of messages that are being signed.
     // TODO (#536): Store batch state and logic on Sui & remove this field.
     BatchedSign(Vec<Vec<u8>>),
@@ -55,11 +55,14 @@ pub enum MPCInitProtocolInfo {
 
 /// The message and data for the Sign round.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub struct SignMessageData {
+pub struct SignSessionData {
     pub batch_session_id: ObjectID,
     pub message: Vec<u8>,
     /// The dWallet ID that is used to sign, needed mostly for audit.
     pub dwallet_id: ObjectID,
+    /// The DKG output of the dWallet, used to sign and verify the message.
+    pub dkg_output: MPCPublicOutput,
+    pub network_key_version: u8,
 }
 
 impl MPCInitProtocolInfo {

--- a/crates/pera-types/src/messages_dwallet_mpc.rs
+++ b/crates/pera-types/src/messages_dwallet_mpc.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use shared_crypto::intent::IntentScope;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub enum MPCRound {
+pub enum MPCInitProtocolInfo {
     /// The first round of the DKG protocol.
     DKGFirst,
     /// The second round of the DKG protocol.
@@ -26,6 +26,7 @@ pub enum MPCRound {
     /// Contains the `ObjectId` of the dWallet object,
     /// the DKG decentralized output, the batch session ID,
     /// and the dWallets' network key version.
+    // TODO (#543): Connect the two presign rounds to one.
     PresignFirst(ObjectID, MPCPublicOutput, ObjectID, u8),
     /// The second round of the Presign protocol.
     /// Contains the `ObjectId` of the dWallet object,
@@ -34,6 +35,7 @@ pub enum MPCRound {
     /// The first and only round of the Sign protocol.
     Sign(SignMessageData),
     /// A batched sign session, contains the list of messages that are being signed.
+    // TODO (#536): Store batch state and logic on Sui & remove this field.
     BatchedSign(Vec<Vec<u8>>),
     BatchedPresign(u64),
     /// The round of the network DKG protocol.
@@ -47,6 +49,7 @@ pub enum MPCRound {
     /// The round of verifying the public key that signed on the encryption key is
     /// matching the initiator address.
     /// todo(zeev): more docs, make it clearer.
+    /// TODO (#544): Check if there's a way to convert the public key to an address in Move.
     EncryptionKeyVerification(StartEncryptionKeyVerificationEvent),
 }
 
@@ -59,21 +62,22 @@ pub struct SignMessageData {
     pub dwallet_id: ObjectID,
 }
 
-impl MPCRound {
+impl MPCInitProtocolInfo {
     /// Returns `true` if the round output is part of a batch, `false` otherwise.
     pub fn is_part_of_batch(&self) -> bool {
         matches!(
             self,
-            MPCRound::Sign(..)
-                | MPCRound::PresignSecond(..)
-                | MPCRound::BatchedSign(..)
-                | MPCRound::BatchedPresign(..)
+            MPCInitProtocolInfo::Sign(..)
+                | MPCInitProtocolInfo::PresignSecond(..)
+                | MPCInitProtocolInfo::BatchedSign(..)
+                | MPCInitProtocolInfo::BatchedPresign(..)
         )
     }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct DWalletMPCEvent {
+    // TODO: remove event - do all parsing beforehand.
     pub event: Event,
     pub session_info: SessionInfo,
 }
@@ -121,12 +125,12 @@ pub struct SessionInfo {
     pub initiating_user_address: PeraAddress,
     /// The current MPC round in the protocol.
     /// Contains extra parameters if needed.
-    pub mpc_round: MPCRound,
+    pub mpc_round: MPCInitProtocolInfo,
 }
 
 /// The Rust representation of the `StartEncryptedShareVerificationEvent` Move struct.
-/// Defined here so that we can use it in the [`MPCRound`] enum,
-/// as the inner data of the [`MPCRound::EncryptedShareVerification`].
+/// Defined here so that we can use it in the [`MPCInitProtocolInfo`] enum,
+/// as the inner data of the [`MPCInitProtocolInfo::EncryptedShareVerification`].
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Eq, PartialEq, Hash)]
 pub struct StartEncryptedShareVerificationEvent {
     pub encrypted_secret_share_and_proof: Vec<u8>,

--- a/crates/pera/src/pera_commands.rs
+++ b/crates/pera/src/pera_commands.rs
@@ -821,13 +821,13 @@ async fn start(
         for (node_index, node) in swarm.validator_nodes().enumerate() {
             // This code is here to turn off & on a validator & test the chain's state sync feature
 
-            if loop_index == 20 && node_index == 3 {
-                error!("Stopping node 3");
-                node.stop();
-            } else if loop_index == 30 && node_index == 3 {
-                error!("Starting node 3");
-                node.start().await?;
-            }
+            // if loop_index == 9 && node_index == 3 {
+            //     error!("Stopping node 3");
+            //     node.stop();
+            // } else if loop_index == 10 && node_index == 3 {
+            //     error!("Starting node 3");
+            //     node.start().await?;
+            // }
 
             if let Some(handle) = node.get_node_handle() {
                 let sequence = handle

--- a/pera-execution/latest/pera-adapter/src/execution_engine.rs
+++ b/pera-execution/latest/pera-adapter/src/execution_engine.rs
@@ -62,7 +62,7 @@ mod checked {
     use pera_types::id::UID;
     use pera_types::inner_temporary_store::InnerTemporaryStore;
     use pera_types::messages_dwallet_mpc::{
-        DWalletMPCOutput, MPCInitProtocolInfo, SignMessageData,
+        DWalletMPCOutput, MPCInitProtocolInfo, SignSessionData,
     };
     #[cfg(msim)]
     use pera_types::pera_system_state::advance_epoch_result_injection::maybe_modify_result;
@@ -1204,7 +1204,7 @@ mod checked {
                     ],
                 )
             }
-            MPCInitProtocolInfo::Sign(SignMessageData {
+            MPCInitProtocolInfo::Sign(SignSessionData {
                 batch_session_id,
                 dwallet_id,
                 ..

--- a/pera-execution/latest/pera-adapter/src/execution_engine.rs
+++ b/pera-execution/latest/pera-adapter/src/execution_engine.rs
@@ -62,7 +62,7 @@ mod checked {
     use pera_types::id::UID;
     use pera_types::inner_temporary_store::InnerTemporaryStore;
     use pera_types::messages_dwallet_mpc::{
-        DWalletMPCOutput, MPCInitProtocolInfo, SignSessionData,
+        DWalletMPCOutput, MPCProtocolInitData, SingleSignSessionData,
     };
     #[cfg(msim)]
     use pera_types::pera_system_state::advance_epoch_result_injection::maybe_modify_result;
@@ -1131,7 +1131,7 @@ mod checked {
         let mut module_name = DWALLET_2PC_MPC_ECDSA_K1_MODULE_NAME;
 
         let (move_function_name, args) = match data.session_info.mpc_round {
-            MPCInitProtocolInfo::DKGFirst => (
+            MPCProtocolInitData::DKGFirst => (
                 "create_dkg_first_round_output",
                 vec![
                     CallArg::Pure(data.session_info.session_id.to_vec()),
@@ -1139,7 +1139,7 @@ mod checked {
                     CallArg::Pure(data.session_info.initiating_user_address.to_vec()),
                 ],
             ),
-            MPCInitProtocolInfo::DKGSecond(event_data, dwallet_network_key_version) => (
+            MPCProtocolInitData::DKGSecond(event_data, dwallet_network_key_version) => (
                 "create_dkg_second_round_output",
                 vec![
                     CallArg::Pure(data.session_info.initiating_user_address.to_vec()),
@@ -1154,7 +1154,7 @@ mod checked {
                     CallArg::Pure(bcs_to_bytes(&event_data.dkg_centralized_public_output)?),
                 ],
             ),
-            MPCInitProtocolInfo::PresignFirst(
+            MPCProtocolInitData::PresignFirst(
                 dwallet_id,
                 dkg_output,
                 batch_session_id,
@@ -1171,7 +1171,7 @@ mod checked {
                     CallArg::Pure(bcs_to_bytes(&network_key_version)?),
                 ],
             ),
-            MPCInitProtocolInfo::PresignSecond(
+            MPCProtocolInitData::PresignSecond(
                 dwallet_id,
                 _first_round_output,
                 batch_session_id,
@@ -1204,7 +1204,7 @@ mod checked {
                     ],
                 )
             }
-            MPCInitProtocolInfo::Sign(SignSessionData {
+            MPCProtocolInitData::Sign(SingleSignSessionData {
                 batch_session_id,
                 dwallet_id,
                 ..
@@ -1219,7 +1219,7 @@ mod checked {
                     CallArg::Pure(bcs_to_bytes(&dwallet_id)?),
                 ],
             ),
-            MPCInitProtocolInfo::NetworkDkg(key_type, new_key) => {
+            MPCProtocolInitData::NetworkDkg(key_type, new_key) => {
                 let new_key = new_key.ok_or(ExecutionError::new(
                     ExecutionErrorKind::TypeArgumentError {
                         argument_idx: 0,
@@ -1245,7 +1245,7 @@ mod checked {
                     ],
                 )
             }
-            MPCInitProtocolInfo::EncryptedShareVerification(verification_data) => (
+            MPCProtocolInitData::EncryptedShareVerification(verification_data) => (
                 "create_encrypted_user_share",
                 vec![
                     CallArg::Pure(verification_data.dwallet_id.bytes.to_vec()),
@@ -1261,7 +1261,7 @@ mod checked {
                     CallArg::Pure(verification_data.initiator.to_vec()),
                 ],
             ),
-            MPCInitProtocolInfo::EncryptionKeyVerification(verification_data) => {
+            MPCProtocolInitData::EncryptionKeyVerification(verification_data) => {
                 module_name = DWALLET_MODULE_NAME;
                 (
                     "create_encryption_key",

--- a/pera-execution/latest/pera-adapter/src/execution_engine.rs
+++ b/pera-execution/latest/pera-adapter/src/execution_engine.rs
@@ -61,7 +61,9 @@ mod checked {
     use pera_types::gas::PeraGasStatus;
     use pera_types::id::UID;
     use pera_types::inner_temporary_store::InnerTemporaryStore;
-    use pera_types::messages_dwallet_mpc::{DWalletMPCOutput, MPCRound, SignMessageData};
+    use pera_types::messages_dwallet_mpc::{
+        DWalletMPCOutput, MPCInitProtocolInfo, SignMessageData,
+    };
     #[cfg(msim)]
     use pera_types::pera_system_state::advance_epoch_result_injection::maybe_modify_result;
     use pera_types::pera_system_state::{
@@ -1129,7 +1131,7 @@ mod checked {
         let mut module_name = DWALLET_2PC_MPC_ECDSA_K1_MODULE_NAME;
 
         let (move_function_name, args) = match data.session_info.mpc_round {
-            MPCRound::DKGFirst => (
+            MPCInitProtocolInfo::DKGFirst => (
                 "create_dkg_first_round_output",
                 vec![
                     CallArg::Pure(data.session_info.session_id.to_vec()),
@@ -1137,7 +1139,7 @@ mod checked {
                     CallArg::Pure(data.session_info.initiating_user_address.to_vec()),
                 ],
             ),
-            MPCRound::DKGSecond(event_data, dwallet_network_key_version) => (
+            MPCInitProtocolInfo::DKGSecond(event_data, dwallet_network_key_version) => (
                 "create_dkg_second_round_output",
                 vec![
                     CallArg::Pure(data.session_info.initiating_user_address.to_vec()),
@@ -1152,7 +1154,7 @@ mod checked {
                     CallArg::Pure(bcs_to_bytes(&event_data.dkg_centralized_public_output)?),
                 ],
             ),
-            MPCRound::PresignFirst(
+            MPCInitProtocolInfo::PresignFirst(
                 dwallet_id,
                 dkg_output,
                 batch_session_id,
@@ -1169,7 +1171,11 @@ mod checked {
                     CallArg::Pure(bcs_to_bytes(&network_key_version)?),
                 ],
             ),
-            MPCRound::PresignSecond(dwallet_id, _first_round_output, batch_session_id) => {
+            MPCInitProtocolInfo::PresignSecond(
+                dwallet_id,
+                _first_round_output,
+                batch_session_id,
+            ) => {
                 let presigns: Vec<(ObjectID, MPCPublicOutput)> = bcs::from_bytes(&data.output)
                     .map_err(|e| {
                         ExecutionError::new(
@@ -1198,7 +1204,7 @@ mod checked {
                     ],
                 )
             }
-            MPCRound::Sign(SignMessageData {
+            MPCInitProtocolInfo::Sign(SignMessageData {
                 batch_session_id,
                 dwallet_id,
                 ..
@@ -1213,7 +1219,7 @@ mod checked {
                     CallArg::Pure(bcs_to_bytes(&dwallet_id)?),
                 ],
             ),
-            MPCRound::NetworkDkg(key_type, new_key) => {
+            MPCInitProtocolInfo::NetworkDkg(key_type, new_key) => {
                 let new_key = new_key.ok_or(ExecutionError::new(
                     ExecutionErrorKind::TypeArgumentError {
                         argument_idx: 0,
@@ -1239,7 +1245,7 @@ mod checked {
                     ],
                 )
             }
-            MPCRound::EncryptedShareVerification(verification_data) => (
+            MPCInitProtocolInfo::EncryptedShareVerification(verification_data) => (
                 "create_encrypted_user_share",
                 vec![
                     CallArg::Pure(verification_data.dwallet_id.bytes.to_vec()),
@@ -1255,7 +1261,7 @@ mod checked {
                     CallArg::Pure(verification_data.initiator.to_vec()),
                 ],
             ),
-            MPCRound::EncryptionKeyVerification(verification_data) => {
+            MPCInitProtocolInfo::EncryptionKeyVerification(verification_data) => {
                 module_name = DWALLET_MODULE_NAME;
                 (
                     "create_encryption_key",

--- a/sdk/typescript/test/e2e/dwallet-mpc.test.ts
+++ b/sdk/typescript/test/e2e/dwallet-mpc.test.ts
@@ -64,6 +64,8 @@ describe('Test dWallet MPC', () => {
 	});
 
 	it('should run Presign', async () => {
+		await new Promise((r) => setTimeout(r, 2000));
+
 		let conf: Config = {
 			keypair: toolbox.keypair,
 			client: toolbox.client,
@@ -101,6 +103,8 @@ describe('Test dWallet MPC', () => {
 			client: toolbox.client,
 			timeout: 10 * 60 * 1000,
 		};
+		//sleep for 2 secs
+		await new Promise((r) => setTimeout(r, 2000));
 		const dWallet = await mockCreateDwallet(conf);
 		expect(dWallet).toBeDefined();
 		console.log({ dWallet });

--- a/sdk/typescript/test/e2e/dwallet-mpc.test.ts
+++ b/sdk/typescript/test/e2e/dwallet-mpc.test.ts
@@ -10,6 +10,7 @@ import { createDWallet } from '../../src/dwallet-mpc/dkg';
 import { createActiveEncryptionKeysTable } from '../../src/dwallet-mpc/encrypt-user-share';
 import {
 	Config,
+	delay,
 	mockedProtocolPublicParameters,
 	MPCKeyScheme,
 } from '../../src/dwallet-mpc/globals';
@@ -50,8 +51,7 @@ describe('Test dWallet MPC', () => {
 			client: toolbox.client,
 			timeout: timeout,
 		};
-		// sleep for 2 seconds
-		await new Promise((r) => setTimeout(r, 2000));
+		await delay(2000);
 		const dWallet = await createDWallet(
 			conf,
 			mockedProtocolPublicParameters,
@@ -64,7 +64,7 @@ describe('Test dWallet MPC', () => {
 	});
 
 	it('should run Presign', async () => {
-		await new Promise((r) => setTimeout(r, 2000));
+		await delay(2000);
 
 		let conf: Config = {
 			keypair: toolbox.keypair,


### PR DESCRIPTION
This makes the sign flow significantly faster, as instead of waiting for all validators to compute the signature, we have to wait only for the fastest one. This PR does not yet cause only one validator to run the last sign step.