### PR TITLE
fix: Agree on malicious report before completing a sign session

### DIFF
--- a/crates/pera-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/pera-core/src/dwallet_mpc/mpc_manager.rs
@@ -232,7 +232,8 @@ impl DWalletMPCManager {
         match status {
             // Quorum reached, remove the malicious parties from the session messages.
             ReportStatus::QuorumReached => {
-                if let Some(session) = self.mpc_sessions.get_mut(&report.session_id) {
+                self.check_for_malicious_ia_report(&report)?;
+                if let Some(mut session) = self.mpc_sessions.get_mut(&report.session_id) {
                     // For every advance we increase the round number by 1,
                     // so to re-run the same round we decrease it by 1.
                     session.pending_quorum_for_highest_round_number -= 1;
@@ -258,28 +259,38 @@ impl DWalletMPCManager {
                         session_id: report.session_id,
                     });
                 };
-                // In the aggregated signing protocol, a single malicious report is enough
-                // to trigger the Sign-Identifiable Abort protocol.
-                // In the Sign-Identifiable Abort protocol, each validator runs the final step,
-                // agreeing on the malicious parties in the session and
-                // removing their messages before the signing session continues as usual.
-                if matches!(
-                    session.session_info.mpc_round,
-                    MPCProtocolInitData::Sign(..)
-                ) && !report.malicious_actors.is_empty()
-                {
-                    if session.session_specific_state.is_none() {
-                        session.session_specific_state =
-                            Some(MPCSessionSpecificState::Sign(SignIASessionState {
-                                malicious_report: report,
-                                initiating_ia_authority: reporting_authority,
-                            }))
-                    }
-                }
+                session.check_for_sign_ia_start(reporting_authority, report);
             }
             ReportStatus::OverQuorum => {}
         }
 
+        Ok(())
+    }
+
+    /// Makes sure the first agreed-upon malicious report in a sign flow is equals to the request
+    /// that triggered the Sign Identifiable Abort flow. If it isn't, we mark the validator that
+    /// sent the request to start the Sign Identifiable Abort flow as malicious, as he sent a faulty
+    /// report.
+    fn check_for_malicious_ia_report(&mut self, report: &MaliciousReport) -> DwalletMPCResult<()> {
+        let Some(mut session) = self.mpc_sessions.get_mut(&report.session_id) else {
+            return Err(DwalletMPCError::MPCSessionNotFound {
+                session_id: report.session_id,
+            });
+        };
+        let Some(MPCSessionSpecificState::Sign(ref mut sign_state)) =
+            &mut session.session_specific_state
+        else {
+            return Err(DwalletMPCError::AggregatedSignStateNotFound {
+                session_id: report.session_id,
+            });
+        };
+        if sign_state.verified_malicious_report.is_none() {
+            sign_state.verified_malicious_report = Some(report.clone());
+            if &sign_state.start_ia_flow_malicious_report != report {
+                self.malicious_handler
+                    .report_malicious_actors(&vec![sign_state.initiating_ia_authority]);
+            }
+        }
         Ok(())
     }
 
@@ -565,31 +576,32 @@ impl DWalletMPCManager {
                 );
                 return;
             };
-            if session.status == MPCSessionStatus::Active {
-                info!(
-                    "running last sign cryptographic step for session_id: {:?}",
-                    session_id
+            if session.status != MPCSessionStatus::Active && !session.is_verifying_sign_ia_report()
+            {
+                return;
+            }
+            info!(
+                "running last sign cryptographic step for session_id: {:?}",
+                session_id
+            );
+            let session = session.clone();
+            if let Err(err) = finished_computation_sender.send(ComputationUpdate::Started) {
+                error!(
+                    "Failed to send a started computation message with error: {:?}",
+                    err
                 );
-                let session = session.clone();
-                if let Err(err) = finished_computation_sender.send(ComputationUpdate::Started) {
+            }
+            rayon::spawn_fifo(move || {
+                if let Err(err) = session.advance(&handle) {
+                    error!("failed to advance session with error: {:?}", err);
+                }
+                if let Err(err) = finished_computation_sender.send(ComputationUpdate::Completed) {
                     error!(
-                        "Failed to send a started computation message with error: {:?}",
+                        "Failed to send a finished computation message with error: {:?}",
                         err
                     );
                 }
-                rayon::spawn_fifo(move || {
-                    if let Err(err) = session.advance(&handle) {
-                        error!("failed to advance session with error: {:?}", err);
-                    }
-                    if let Err(err) = finished_computation_sender.send(ComputationUpdate::Completed)
-                    {
-                        error!(
-                            "Failed to send a finished computation message with error: {:?}",
-                            err
-                        );
-                    }
-                });
-            }
+            });
         });
         Ok(())
     }

--- a/crates/pera-core/src/dwallet_mpc/mpc_outputs_verifier.rs
+++ b/crates/pera-core/src/dwallet_mpc/mpc_outputs_verifier.rs
@@ -148,39 +148,7 @@ impl DWalletMPCOutputsVerifier {
             return match Self::verify_signature(&epoch_store, sign_session_data, output) {
                 Ok(res) => {
                     session_output_data.current_result = OutputResult::AlreadyCommitted;
-                    let mpc_manager = epoch_store.get_dwallet_mpc_manager().await;
-                    let session = mpc_manager
-                        .mpc_sessions
-                        .get(&session_info.session_id)
-                        .ok_or(DwalletMPCError::MPCSessionNotFound {
-                            session_id: session_info.session_id,
-                        })?;
                     let mut session_malicious_actors = res.malicious_actors;
-                    if let Some(MPCSessionSpecificState::Sign(sign_state)) =
-                        &session.session_specific_state
-                    {
-                        // If one of the validators in the sign session sent a malicious report,
-                        // every validator needs
-                        // to make sure the reported validator actually marked
-                        // as malicious
-                        // before the sign session got completed.
-                        // If the reported validator was not malicious, the reporting
-                        // validator should be marked as malicious.
-                        for reported_malicious_actor in
-                            &sign_state.malicious_report.malicious_actors
-                        {
-                            if !mpc_manager
-                                .malicious_handler
-                                .get_malicious_actors_names()
-                                .contains(&reported_malicious_actor)
-                            {
-                                warn!("a sign session got completed successfully while the reported malicious actor {:?} was not malicious,\
-                                 marking the reporting: {:?} authority as malicious", reported_malicious_actor, sign_state.initiating_ia_authority);
-                                session_malicious_actors.push(sign_state.initiating_ia_authority);
-                                break;
-                            }
-                        }
-                    }
                     Ok(OutputVerificationResult {
                         result: OutputResult::Valid,
                         malicious_actors: session_malicious_actors,

--- a/crates/pera-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/pera-core/src/dwallet_mpc/mpc_session.rs
@@ -10,7 +10,7 @@ use tokio::runtime::Handle;
 use tracing::error;
 use twopc_mpc::sign::Protocol;
 
-use pera_types::base_types::{EpochId, ObjectID};
+use pera_types::base_types::{AuthorityName, EpochId, ObjectID};
 use pera_types::committee::StakeUnit;
 use pera_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use pera_types::id::ID;
@@ -144,6 +144,13 @@ impl DWalletMPCSession {
                 let output = self.new_dwallet_mpc_output_message(public_output)?;
                 let consensus_adapter = self.consensus_adapter.clone();
                 let epoch_store = self.epoch_store()?.clone();
+                if self.is_verifying_sign_ia_report() {
+                    self.send_empty_malicious_report(
+                        tokio_runtime_handle,
+                        &consensus_adapter,
+                        &epoch_store,
+                    )?;
+                }
                 tokio_runtime_handle.spawn(async move {
                     if let Err(err) = consensus_adapter
                         .submit_to_consensus(&vec![output], &epoch_store)
@@ -152,6 +159,7 @@ impl DWalletMPCSession {
                         error!("failed to submit an MPC message to consensus: {:?}", err);
                     }
                 });
+
                 Ok(())
             }
             Err(DwalletMPCError::SessionFailedWithMaliciousParties(malicious_parties)) => {
@@ -187,6 +195,67 @@ impl DWalletMPCSession {
                 Err(e)
             }
         }
+    }
+
+    /// Returns true if the session is still verifying that a Start Sign Identifiable Report
+    /// message is valid; false otherwise.
+    /// The Sign Identifiable Abort protocol differs from other protocols as,
+    /// besides verifying that the output is valid, we must also verify that the malicious report,
+    /// which caused all other validators to spend extra resources, was honest.
+    pub(crate) fn is_verifying_sign_ia_report(&self) -> bool {
+        let Some(MPCSessionSpecificState::Sign(sign_state)) = &self.session_specific_state else {
+            return false;
+        };
+        sign_state.verified_malicious_report.is_none()
+    }
+
+    /// Starts the Sign Identifiable Abort protocol if needed.
+    ///
+    /// In the aggregated signing protocol, a single malicious report is enough
+    /// to trigger the Sign-Identifiable Abort protocol.
+    /// In the Sign-Identifiable Abort protocol, each validator runs the final step,
+    /// agreeing on the malicious parties in the session and
+    /// removing their messages before the signing session continues as usual.
+    pub(crate) fn check_for_sign_ia_start(
+        &mut self,
+        reporting_authority: AuthorityName,
+        report: MaliciousReport,
+    ) {
+        if matches!(self.session_info.mpc_round, MPCProtocolInitData::Sign(..))
+            && self.status == MPCSessionStatus::Active
+            && self.session_specific_state.is_none()
+        {
+            self.session_specific_state = Some(MPCSessionSpecificState::Sign(SignIASessionState {
+                start_ia_flow_malicious_report: report,
+                initiating_ia_authority: reporting_authority,
+                verified_malicious_report: None,
+            }))
+        }
+    }
+
+    /// In the Sign Identifiable Abort protocol, each validator sends a malicious report, even
+    /// if no malicious actors are found. This is necessary to reach agreement on a malicious report
+    /// and to punish the validator who started the Sign IA report if they sent a faulty report.
+    fn send_empty_malicious_report(
+        &self,
+        tokio_runtime_handle: &Handle,
+        consensus_adapter: &Arc<dyn SubmitToConsensus>,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> DwalletMPCResult<()> {
+        let empty_report = MaliciousReport::new(vec![], self.session_info.session_id.clone());
+        let report_output =
+            self.new_dwallet_report_failed_session_with_malicious_actors(empty_report)?;
+        let epoch_store = epoch_store.clone();
+        let consensus_adapter = consensus_adapter.clone();
+        tokio_runtime_handle.spawn(async move {
+            if let Err(err) = consensus_adapter
+                .submit_to_consensus(&vec![report_output], &epoch_store)
+                .await
+            {
+                error!("failed to submit an MPC message to consensus: {:?}", err);
+            }
+        });
+        Ok(())
     }
 
     fn advance_specific_party(

--- a/crates/pera-types/src/dwallet_mpc_error.rs
+++ b/crates/pera-types/src/dwallet_mpc_error.rs
@@ -7,6 +7,9 @@ pub enum DwalletMPCError {
     #[error("mpc session with ID `{session_id:?}` was not found")]
     MPCSessionNotFound { session_id: ObjectID },
 
+    #[error("sign state for the session with ID `{session_id:?}` was not found")]
+    AggregatedSignStateNotFound { session_id: ObjectID },
+
     #[error("mpc session with ID `{session_id:?}`, failed: {error}")]
     MPCSessionError { session_id: ObjectID, error: String },
 

--- a/crates/pera-types/src/messages_dwallet_mpc.rs
+++ b/crates/pera-types/src/messages_dwallet_mpc.rs
@@ -71,7 +71,16 @@ pub enum MPCSessionSpecificState {
 /// The state of a sign-identifiable abort session.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct SignIASessionState {
-    pub malicious_report: MaliciousReport,
+    /// The first report that triggered the beginning of the Sign Identifiable Abort protocol,
+    /// in which, instead of having only one validator run the last sign step, every validator runs
+    /// the last step to agree on the malicious actors.
+    pub start_ia_flow_malicious_report: MaliciousReport,
+    /// The malicious report that have been agreed upon by a quorum of validators. If this report
+    /// is different from the `start_ia_flow_malicious_report`, the authority that sent the
+    /// `start_ia_flow_malicious_report` is being marked as malicious.
+    pub verified_malicious_report: Option<MaliciousReport>,
+    /// The first authority that sent a [`MaliciousReport`] in this sign session and triggered
+    /// the beginning of the Sign Identifiable Abort flow.
     pub initiating_ia_authority: AuthorityName,
 }
 


### PR DESCRIPTION
Until now, a sign flow was considered complete when a valid signature arrived. If the malicious actors reported in the triggering report were not agreed upon as malicious by a quorum by that time, the reporter would be marked as malicious. This behavior is problematic because a valid signature does not imply the absence of a quorum of validators agreeing on the report. This PR changes this behavior and enforces agreement on the malicious report before completing an aggregated sign session.  