### PR TITLE
fix: Don't remove the previous computation round when receiving a quorum for the next round

### DIFF
--- a/crates/pera-core/src/dwallet_mpc/cryptographic_computations_orchestrator.rs
+++ b/crates/pera-core/src/dwallet_mpc/cryptographic_computations_orchestrator.rs
@@ -83,13 +83,6 @@ impl CryptographicComputationsOrchestrator {
     /// computations, the obsolete computation is removed.
     pub(crate) fn insert_ready_sessions(&mut self, sessions: Vec<DWalletMPCSession>) {
         for session in sessions.into_iter() {
-            if session.pending_quorum_for_highest_round_number > 0 {
-                self.pending_computation_map
-                    .remove(&DWalletMPCLocalComputationMetadata {
-                        session_id: session.session_info.session_id,
-                        crypto_round_number: session.pending_quorum_for_highest_round_number - 1,
-                    });
-            }
             let session_next_round_metadata = DWalletMPCLocalComputationMetadata {
                 session_id: session.session_info.session_id,
                 crypto_round_number: session.pending_quorum_for_highest_round_number,


### PR DESCRIPTION
This should not be done as we don't know if the quorum of messages are valid, and if not our message may still be needed.