### PR TITLE
fix: Update the committee constants to use fixed sizes for development

### DIFF
--- a/crates/ika-move-packages/packages/ika_system/sources/system_v1/committee.move
+++ b/crates/ika-move-packages/packages/ika_system/sources/system_v1/committee.move
@@ -25,14 +25,14 @@ public struct Committee has store, copy, drop {
 /// opaque quantities whose meaning changes from epoch to epoch as the total amount staked shifts.
 /// Fixing the total voting power allows clients to hardcode the quorum threshold and total_voting power rather
 /// than recomputing these.
-const TOTAL_VOTING_POWER: u64 = 10_000;
+const TOTAL_VOTING_POWER: u64 = 4;
 
 /// Quorum threshold for our fixed voting power - any message signed by this much voting power can be trusted
 /// up to BFT assumptions
-const QUORUM_THRESHOLD: u64 = 6_667;
+const QUORUM_THRESHOLD: u64 = 3;
 
 // Cap voting power of an individual validator at 10%.
-const MAX_VOTING_POWER: u64 = 1_000;
+const MAX_VOTING_POWER: u64 = 1;
 
 const BLS_SIGNATURE_LEN: u64 = 96;
 

--- a/crates/ika-types/src/committee.rs
+++ b/crates/ika-types/src/committee.rs
@@ -37,14 +37,14 @@ pub type CommitteeDigest = [u8; 32];
 /// as easily understandable basis points (e.g., voting_power: 100 = 1%, voting_power: 1 = 0.01%).
 /// Fixing the total voting power allows clients to hardcode the quorum threshold and total_voting power rather
 /// than recomputing these.
-pub const TOTAL_VOTING_POWER: StakeUnit = 10_000;
+pub const TOTAL_VOTING_POWER: StakeUnit = 4;
 
 /// Quorum threshold for our fixed voting power--any message signed by this much voting power can be trusted
 /// up to BFT assumptions
-pub const QUORUM_THRESHOLD: StakeUnit = 6_667;
+pub const QUORUM_THRESHOLD: StakeUnit = 3;
 
 /// Validity threshold defined by f+1
-pub const VALIDITY_THRESHOLD: StakeUnit = 3_334;
+pub const VALIDITY_THRESHOLD: StakeUnit = 1;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq)]
 pub struct Committee {


### PR DESCRIPTION
Most of the files in this PR are generated Markdown files that changed when I built the Ika Move packages.  
The only files that actually changed are:  
- `crates/ika-types/src/committee.rs`  
- `crates/ika-move-packages/packages/ika_system/sources/system_v1/committee.move`