### PR TITLE
fix: Make the `DWalletMPCService` start with the new Move code

### DIFF
--- a/crates/ika-move-packages/docs/dwallet_2pc_mpc_secp256k1.md
+++ b/crates/ika-move-packages/docs/dwallet_2pc_mpc_secp256k1.md
@@ -149,7 +149,7 @@ Create a new System object and make it shared.
 This function will be called only once in init.
 
 
-<pre><code><b>public</b>(package) <b>fun</b> <a href="../ika_system/dwallet_2pc_mpc_secp256k1.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_create">create</a>(package_id: <a href="../../sui/object.md#sui_object_ID">sui::object::ID</a>, epoch: u64, active_committee: (ika_system=0x0)::<a href="../ika_system/committee.md#(ika_system=0x0)_committee_Committee">committee::Committee</a>, pricing: (ika_system=0x0)::<a href="../ika_system/dwallet_pricing.md#(ika_system=0x0)_dwallet_pricing_DWalletPricing2PcMpcSecp256K1">dwallet_pricing::DWalletPricing2PcMpcSecp256K1</a>, ctx: &<b>mut</b> <a href="../../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): (<a href="../../sui/object.md#sui_object_ID">sui::object::ID</a>, (ika_system=0x0)::<a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkrkDecryptionKeyCap">dwallet_2pc_mpc_secp256k1_inner::DWalletNetworkrkDecryptionKeyCap</a>)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../ika_system/dwallet_2pc_mpc_secp256k1.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_create">create</a>(package_id: <a href="../../sui/object.md#sui_object_ID">sui::object::ID</a>, epoch: u64, active_committee: (ika_system=0x0)::<a href="../ika_system/committee.md#(ika_system=0x0)_committee_Committee">committee::Committee</a>, pricing: (ika_system=0x0)::<a href="../ika_system/dwallet_pricing.md#(ika_system=0x0)_dwallet_pricing_DWalletPricing2PcMpcSecp256K1">dwallet_pricing::DWalletPricing2PcMpcSecp256K1</a>, ctx: &<b>mut</b> <a href="../../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): (<a href="../../sui/object.md#sui_object_ID">sui::object::ID</a>, (ika_system=0x0)::<a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkDecryptionKeyCap">dwallet_2pc_mpc_secp256k1_inner::DWalletNetworkDecryptionKeyCap</a>)
 </code></pre>
 
 
@@ -164,7 +164,7 @@ This function will be called only once in init.
     active_committee: Committee,
     pricing: DWalletPricing2PcMpcSecp256K1,
     ctx: &<b>mut</b> TxContext
-): (ID, DWalletNetworkrkDecryptionKeyCap) {
+): (ID, DWalletNetworkDecryptionKeyCap) {
     <b>let</b> <b>mut</b> <a href="../ika_system/dwallet_2pc_mpc_secp256k1.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1">dwallet_2pc_mpc_secp256k1</a> = <a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_create">dwallet_2pc_mpc_secp256k1_inner::create</a>(
         epoch,
         active_committee,

--- a/crates/ika-move-packages/docs/dwallet_2pc_mpc_secp256k1_inner.md
+++ b/crates/ika-move-packages/docs/dwallet_2pc_mpc_secp256k1_inner.md
@@ -9,7 +9,7 @@ protocols to ensure trustless and decentralized wallet creation and key manageme
 
 -  [Struct `DWallet2PcMpcSecp256K1InnerV1`](#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWallet2PcMpcSecp256K1InnerV1)
 -  [Struct `DWalletCap`](#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletCap)
--  [Struct `DWalletNetworkrkDecryptionKeyCap`](#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkrkDecryptionKeyCap)
+-  [Struct `DWalletNetworkDecryptionKeyCap`](#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkDecryptionKeyCap)
 -  [Struct `DWalletNetworkDecryptionKey`](#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkDecryptionKey)
 -  [Struct `EncryptionKey`](#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_EncryptionKey)
 -  [Struct `EncryptedUserSecretKeyShare`](#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_EncryptedUserSecretKeyShare)
@@ -261,14 +261,14 @@ Represents a capability granting control over a specific dWallet.
 
 </details>
 
-<a name="(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkrkDecryptionKeyCap"></a>
+<a name="(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkDecryptionKeyCap"></a>
 
-## Struct `DWalletNetworkrkDecryptionKeyCap`
+## Struct `DWalletNetworkDecryptionKeyCap`
 
 Represents a capability granting control over a specific dWallet network decryption key.
 
 
-<pre><code><b>public</b> <b>struct</b> <a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkrkDecryptionKeyCap">DWalletNetworkrkDecryptionKeyCap</a> <b>has</b> key, store
+<pre><code><b>public</b> <b>struct</b> <a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkDecryptionKeyCap">DWalletNetworkDecryptionKeyCap</a> <b>has</b> key, store
 </code></pre>
 
 
@@ -2221,7 +2221,7 @@ Supported hash schemes for message signing.
 
 
 
-<pre><code><b>public</b>(package) <b>fun</b> <a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_create_dwallet_network_decryption_key">create_dwallet_network_decryption_key</a>(self: &<b>mut</b> (ika_system=0x0)::<a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWallet2PcMpcSecp256K1InnerV1">dwallet_2pc_mpc_secp256k1_inner::DWallet2PcMpcSecp256K1InnerV1</a>, ctx: &<b>mut</b> <a href="../../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): (ika_system=0x0)::<a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkrkDecryptionKeyCap">dwallet_2pc_mpc_secp256k1_inner::DWalletNetworkrkDecryptionKeyCap</a>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_create_dwallet_network_decryption_key">create_dwallet_network_decryption_key</a>(self: &<b>mut</b> (ika_system=0x0)::<a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWallet2PcMpcSecp256K1InnerV1">dwallet_2pc_mpc_secp256k1_inner::DWallet2PcMpcSecp256K1InnerV1</a>, ctx: &<b>mut</b> <a href="../../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): (ika_system=0x0)::<a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkDecryptionKeyCap">dwallet_2pc_mpc_secp256k1_inner::DWalletNetworkDecryptionKeyCap</a>
 </code></pre>
 
 
@@ -2233,7 +2233,7 @@ Supported hash schemes for message signing.
 <pre><code><b>public</b>(package) <b>fun</b> <a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_create_dwallet_network_decryption_key">create_dwallet_network_decryption_key</a>(
     self: &<b>mut</b> <a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWallet2PcMpcSecp256K1InnerV1">DWallet2PcMpcSecp256K1InnerV1</a>,
     ctx: &<b>mut</b> TxContext
-): <a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkrkDecryptionKeyCap">DWalletNetworkrkDecryptionKeyCap</a> {
+): <a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkDecryptionKeyCap">DWalletNetworkDecryptionKeyCap</a> {
     <b>let</b> id = object::new(ctx);
     <b>let</b> dwallet_network_decryption_key_id = id.to_inner();
     self.dwallet_network_decryption_keys.add(dwallet_network_decryption_key_id, <a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkDecryptionKey">DWalletNetworkDecryptionKey</a> {
@@ -2245,7 +2245,7 @@ Supported hash schemes for message signing.
         public_output: vector[],
         state: DWalletNetworkDecryptionKeyState::AwaitingNetworkDKG,
     });
-    <a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkrkDecryptionKeyCap">DWalletNetworkrkDecryptionKeyCap</a> {
+    <a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkDecryptionKeyCap">DWalletNetworkDecryptionKeyCap</a> {
         id: object::new(ctx),
         dwallet_network_decryption_key_id,
     }

--- a/crates/ika-move-packages/docs/system_inner.md
+++ b/crates/ika-move-packages/docs/system_inner.md
@@ -317,7 +317,7 @@ Uses SystemParametersV1 as the parameters.
 <dd>
 </dd>
 <dt>
-<code>dwallet_network_decryption_key: <a href="../../std/option.md#std_option_Option">std::option::Option</a>&lt;(ika_system=0x0)::<a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkrkDecryptionKeyCap">dwallet_2pc_mpc_secp256k1_inner::DWalletNetworkrkDecryptionKeyCap</a>&gt;</code>
+<code>dwallet_network_decryption_key: <a href="../../std/option.md#std_option_Option">std::option::Option</a>&lt;(ika_system=0x0)::<a href="../ika_system/dwallet_2pc_mpc_secp256k1_inner.md#(ika_system=0x0)_dwallet_2pc_mpc_secp256k1_inner_DWalletNetworkDecryptionKeyCap">dwallet_2pc_mpc_secp256k1_inner::DWalletNetworkDecryptionKeyCap</a>&gt;</code>
 </dt>
 <dd>
 </dd>

--- a/crates/ika-move-packages/packages/ika_system/sources/dwallet/dwallet_2pc_mpc_secp256k1_inner.move
+++ b/crates/ika-move-packages/packages/ika_system/sources/dwallet/dwallet_2pc_mpc_secp256k1_inner.move
@@ -66,7 +66,7 @@ public struct DWalletCap has key, store {
 }
 
 /// Represents a capability granting control over a specific dWallet network decryption key.
-public struct DWalletNetworkrkDecryptionKeyCap has key, store {
+public struct DWalletNetworkDecryptionKeyCap has key, store {
     id: UID,
     dwallet_network_decryption_key_id: ID,
 }
@@ -645,7 +645,7 @@ public(package) fun create(
 public(package) fun create_dwallet_network_decryption_key(
     self: &mut DWallet2PcMpcSecp256K1InnerV1,
     ctx: &mut TxContext
-): DWalletNetworkrkDecryptionKeyCap {
+): DWalletNetworkDecryptionKeyCap {
     let id = object::new(ctx);
     let dwallet_network_decryption_key_id = id.to_inner();
     self.dwallet_network_decryption_keys.add(dwallet_network_decryption_key_id, DWalletNetworkDecryptionKey {
@@ -657,7 +657,7 @@ public(package) fun create_dwallet_network_decryption_key(
         public_output: vector[],
         state: DWalletNetworkDecryptionKeyState::AwaitingNetworkDKG,
     });
-    DWalletNetworkrkDecryptionKeyCap {
+    DWalletNetworkDecryptionKeyCap {
         id: object::new(ctx),
         dwallet_network_decryption_key_id,
     }

--- a/crates/ika-move-packages/packages/ika_system/sources/dwallet_2pc_mpc_secp256k1.move
+++ b/crates/ika-move-packages/packages/ika_system/sources/dwallet_2pc_mpc_secp256k1.move
@@ -8,7 +8,7 @@ use ika_system::dwallet_pricing::{DWalletPricing2PcMpcSecp256K1};
 use ika_system::dwallet_2pc_mpc_secp256k1_inner::{
     Self,
     DWallet2PcMpcSecp256K1InnerV1,
-    DWalletNetworkrkDecryptionKeyCap,
+    DWalletNetworkDecryptionKeyCap,
     EncryptionKey,
     DWalletCap,
     MessageApproval,
@@ -40,7 +40,7 @@ public(package) fun create(
     active_committee: Committee,
     pricing: DWalletPricing2PcMpcSecp256K1,
     ctx: &mut TxContext
-): (ID, DWalletNetworkrkDecryptionKeyCap) {
+): (ID, DWalletNetworkDecryptionKeyCap) {
     let mut dwallet_2pc_mpc_secp256k1 = dwallet_2pc_mpc_secp256k1_inner::create(
         epoch,
         active_committee,

--- a/crates/ika-move-packages/packages/ika_system/sources/system_v1/system_inner.move
+++ b/crates/ika-move-packages/packages/ika_system/sources/system_v1/system_inner.move
@@ -12,7 +12,7 @@ use ika_system::validator_set::{ValidatorSet};
 use ika_system::committee::{Committee};
 use ika_system::protocol_cap::ProtocolCap;
 use ika_system::dwallet_2pc_mpc_secp256k1;
-use ika_system::dwallet_2pc_mpc_secp256k1_inner::{DWalletNetworkrkDecryptionKeyCap};
+use ika_system::dwallet_2pc_mpc_secp256k1_inner::{DWalletNetworkDecryptionKeyCap};
 use sui::bag::{Self, Bag};
 use sui::balance::{Self, Balance};
 use sui::coin::Coin;
@@ -89,7 +89,7 @@ public struct SystemInnerV1 has store {
     // TODO: maybe change that later
     dwallet_2pc_mpc_secp256k1_id: Option<ID>,
     // TODO: dummy code, change that later
-    dwallet_network_decryption_key: Option<DWalletNetworkrkDecryptionKeyCap>,
+    dwallet_network_decryption_key: Option<DWalletNetworkDecryptionKeyCap>,
     /// Any extra fields that's not defined statically.
     extra_fields: Bag,
 }

--- a/crates/ika-move-packages/published_api.txt
+++ b/crates/ika-move-packages/published_api.txt
@@ -109,7 +109,7 @@ DWallet2PcMpcSecp256K1InnerV1
 DWalletCap
 	public struct
 	0x0::dwallet_2pc_mpc_secp256k1_inner
-DWalletNetworkrkDecryptionKeyCap
+DWalletNetworkDecryptionKeyCap
 	public struct
 	0x0::dwallet_2pc_mpc_secp256k1_inner
 DWalletNetworkDecryptionKey

--- a/crates/ika-types/src/sui/system_inner_v1.rs
+++ b/crates/ika-types/src/sui/system_inner_v1.rs
@@ -94,8 +94,8 @@ pub struct UpgradeCap {
 /// Represents a capability granting control over a specific dWallet network decryption key.
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct DWalletNetworkDecryptionKeyCap {
-    pub id: ID,
-    pub dwallet_network_decryption_key_id: ID,
+    pub id: ObjectID,
+    pub dwallet_network_decryption_key_id: ObjectID,
 }
 
 /// Rust version of the Move ika_system::ika_system::IkaSystemStateInner type
@@ -114,6 +114,7 @@ pub struct SystemInnerV1 {
     pub previous_epoch_last_checkpoint_sequence_number: u64,
     pub computation_reward: Balance,
     pub authorized_protocol_cap_ids: Vec<ObjectID>,
+    pub dwallet_2pc_mpc_secp256k1_id: Option<ObjectID>,
     pub dwallet_network_decryption_key: Option<DWalletNetworkDecryptionKeyCap>,
     pub extra_fields: Bag,
     // TODO: Use getters instead of all pub.

--- a/crates/ika-types/src/sui/system_inner_v1.rs
+++ b/crates/ika-types/src/sui/system_inner_v1.rs
@@ -91,6 +91,12 @@ pub struct UpgradeCap {
     pub policy: u8,
 }
 
+/// Represents a capability granting control over a specific dWallet network decryption key.
+pub struct DWalletNetworkDecryptionKeyCap {
+id: ObjectID,
+dwallet_network_decryption_key_id: ID,
+}
+
 /// Rust version of the Move ika_system::ika_system::IkaSystemStateInner type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct SystemInnerV1 {
@@ -107,6 +113,7 @@ pub struct SystemInnerV1 {
     pub previous_epoch_last_checkpoint_sequence_number: u64,
     pub computation_reward: Balance,
     pub authorized_protocol_cap_ids: Vec<ObjectID>,
+    pub dwallet_network_decryption_key: Option<DWalletNetworkDecryptionKeyCap>,
     pub extra_fields: Bag,
     // TODO: Use getters instead of all pub.
 }

--- a/crates/ika-types/src/sui/system_inner_v1.rs
+++ b/crates/ika-types/src/sui/system_inner_v1.rs
@@ -92,9 +92,10 @@ pub struct UpgradeCap {
 }
 
 /// Represents a capability granting control over a specific dWallet network decryption key.
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct DWalletNetworkDecryptionKeyCap {
-id: ObjectID,
-dwallet_network_decryption_key_id: ID,
+    pub id: ID,
+    pub dwallet_network_decryption_key_id: ID,
 }
 
 /// Rust version of the Move ika_system::ika_system::IkaSystemStateInner type

--- a/crates/ika-types/src/sui/system_inner_v1.rs
+++ b/crates/ika-types/src/sui/system_inner_v1.rs
@@ -66,6 +66,8 @@ pub struct Committee {
     pub total_aggregated_key: Element,
 }
 
+
+
 /// Rust version of the Move ika_system::validator_set::ValidatorSet type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct ValidatorSetV1 {
@@ -73,6 +75,7 @@ pub struct ValidatorSetV1 {
     pub validators: Table, //ObjectTable
     pub active_committee: Committee,
     pub next_epoch_active_committee: Option<Committee>,
+    pub previous_committee: Committee,
     pub pending_active_validators: Vec<ObjectID>,
     pub at_risk_validators: VecMap<ID, u64>,
     pub validator_report_records: VecMap<ObjectID, VecSet<ObjectID>>,

--- a/crates/ika-types/src/sui/system_inner_v1.rs
+++ b/crates/ika-types/src/sui/system_inner_v1.rs
@@ -66,8 +66,6 @@ pub struct Committee {
     pub total_aggregated_key: Element,
 }
 
-
-
 /// Rust version of the Move ika_system::validator_set::ValidatorSet type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct ValidatorSetV1 {


### PR DESCRIPTION
After fetching the new Move code, I forgot to update the Rust code structs to match the new Move structs, and this prevented the chain from starting successfully. This PR mitigates this issue, and fixes one typo.