### PR TITLE
Patch 'should encrypt a secret share' issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1753,19 +1753,19 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "class_groups"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
 dependencies = [
- "commitment",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "criterion",
- "crypto-bigint 0.6.0-rc.6",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
  "crypto-primes",
- "group 0.1.0",
- "homomorphic_encryption",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "homomorphic_encryption 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "itertools 0.13.0",
- "maurer",
+ "maurer 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "merlin",
- "mpc",
- "proof",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "proof 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -1785,9 +1785,9 @@ dependencies = [
  "base64 0.22.1",
  "bcs",
  "class_groups",
- "group 0.1.0",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "log",
- "mpc",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "schemars",
  "serde",
  "twopc_mpc",
@@ -1923,8 +1923,20 @@ name = "commitment"
 version = "0.1.0"
 source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
 dependencies = [
- "crypto-bigint 0.6.0-rc.6",
- "group 0.1.0",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "merlin",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "commitment"
+version = "0.1.0"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
+dependencies = [
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "merlin",
  "serde",
  "thiserror 1.0.69",
@@ -2337,6 +2349,17 @@ name = "crypto-bigint"
 version = "0.6.0-rc.6"
 source = "git+https://github.com/erik-3milabs/crypto-bigint.git?rev=271d029#271d02932e6aa93e6585ecf1cffdb34d7fecdea4"
 dependencies = [
+ "num-traits",
+ "rand_core 0.6.4",
+ "serdect 0.3.0-rc.0",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.6.0-rc.6"
+source = "git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad#71d665add85dfd3f9b2cbf1296c7cd31b2cbb93a"
+dependencies = [
  "hybrid-array",
  "num-traits",
  "rand_core 0.6.4",
@@ -2383,7 +2406,7 @@ version = "0.6.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9fad3f7645c77d3e0269f3e74a8dd25746de992b16bcecbb316059836e0b366"
 dependencies = [
- "crypto-bigint 0.6.0-rc.6",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
  "rand_core 0.6.4",
 ]
 
@@ -2537,7 +2560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2928,10 +2951,10 @@ dependencies = [
  "anyhow",
  "bcs",
  "class_groups",
- "crypto-bigint 0.6.0-rc.6",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=271d029)",
  "fastcrypto",
  "flate2",
- "group 0.1.0",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "ika-types",
  "rand_chacha 0.3.1",
  "schemars",
@@ -2950,15 +2973,15 @@ dependencies = [
  "bcs",
  "class_groups",
  "class_groups_constants",
- "commitment",
- "crypto-bigint 0.6.0-rc.6",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=271d029)",
  "dwallet-mpc-types",
- "group 0.1.0",
- "homomorphic_encryption",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "homomorphic_encryption 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "k256 0.14.0-pre.2",
  "log",
- "maurer",
- "mpc",
+ "maurer 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "schemars",
@@ -3108,7 +3131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc43715037532dc2d061e5c97e81b684c28993d52a4fa4eb7d2ce2826d78f2f2"
 dependencies = [
  "base16ct 0.2.0",
- "crypto-bigint 0.6.0-rc.6",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
  "digest 0.11.0-pre.9",
  "ff 0.13.0",
  "group 0.13.0",
@@ -3154,17 +3177,17 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "enhanced_maurer"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
 dependencies = [
- "commitment",
- "crypto-bigint 0.6.0-rc.6",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
  "getrandom 0.2.15",
- "group 0.1.0",
- "homomorphic_encryption",
- "maurer",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "homomorphic_encryption 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "maurer 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "merlin",
- "mpc",
- "proof",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "proof 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -4247,7 +4270,25 @@ name = "group"
 version = "0.1.0"
 source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
 dependencies = [
- "crypto-bigint 0.6.0-rc.6",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
+ "curve25519-dalek-ng",
+ "getrandom 0.2.15",
+ "itertools 0.13.0",
+ "k256 0.14.0-pre.2",
+ "serde",
+ "sha3 0.11.0-pre.4",
+ "sha3 0.9.1",
+ "subtle",
+ "subtle-ng",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "group"
+version = "0.1.0"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
+dependencies = [
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
  "curve25519-dalek-ng",
  "getrandom 0.2.15",
  "itertools 0.13.0",
@@ -4524,9 +4565,21 @@ name = "homomorphic_encryption"
 version = "0.1.0"
 source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
 dependencies = [
- "crypto-bigint 0.6.0-rc.6",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
  "getrandom 0.2.15",
- "group 0.1.0",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "homomorphic_encryption"
+version = "0.1.0"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
+dependencies = [
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
+ "getrandom 0.2.15",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rstest 0.22.0",
@@ -4641,7 +4694,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -5059,12 +5112,12 @@ dependencies = [
  "clap",
  "class_groups",
  "class_groups_constants",
- "commitment",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
  "consensus-config",
  "consensus-core",
  "count-min-sketch",
  "criterion",
- "crypto-bigint 0.6.0-rc.6",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=271d029)",
  "dashmap",
  "derive_more 1.0.0",
  "diffy",
@@ -5079,8 +5132,8 @@ dependencies = [
  "fastcrypto-zkp",
  "fs_extra",
  "futures",
- "group 0.1.0",
- "homomorphic_encryption",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "homomorphic_encryption 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "ika-config",
  "ika-move-packages",
  "ika-network",
@@ -5101,7 +5154,7 @@ dependencies = [
  "move-core-types",
  "move-package",
  "move-symbol-pool",
- "mpc",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "mysten-common",
  "mysten-metrics",
  "mysten-network",
@@ -5500,7 +5553,7 @@ dependencies = [
  "fastcrypto",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
- "group 0.1.0",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "ika-protocol-config",
  "im",
  "indexmap 2.7.1",
@@ -6306,9 +6359,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 dependencies = [
  "serde",
 ]
@@ -6415,14 +6468,32 @@ name = "maurer"
 version = "0.1.0"
 source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
 dependencies = [
- "commitment",
- "crypto-bigint 0.6.0-rc.6",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
  "getrandom 0.2.15",
- "group 0.1.0",
- "homomorphic_encryption",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "homomorphic_encryption 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
  "merlin",
- "mpc",
- "proof",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "proof 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "maurer"
+version = "0.1.0"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
+dependencies = [
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
+ "getrandom 0.2.15",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "homomorphic_encryption 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "merlin",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "proof 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -7405,12 +7476,28 @@ name = "mpc"
 version = "0.1.0"
 source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
 dependencies = [
- "commitment",
- "criterion",
- "crypto-bigint 0.6.0-rc.6",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
  "gcd",
  "getrandom 0.2.15",
- "group 0.1.0",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "mpc"
+version = "0.1.0"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
+dependencies = [
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "criterion",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
+ "gcd",
+ "getrandom 0.2.15",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rayon",
@@ -7966,7 +8053,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.2.0",
  "proc-macro2 1.0.93",
  "quote 1.0.38",
  "syn 2.0.98",
@@ -9013,15 +9100,34 @@ version = "0.1.0"
 source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
 dependencies = [
  "bulletproofs",
- "commitment",
- "criterion",
- "crypto-bigint 0.6.0-rc.6",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
  "curve25519-dalek-ng",
  "getrandom 0.2.15",
- "group 0.1.0",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
  "itertools 0.13.0",
  "merlin",
- "mpc",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "proof"
+version = "0.1.0"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
+dependencies = [
+ "bulletproofs",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "criterion",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
+ "curve25519-dalek-ng",
+ "getrandom 0.2.15",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "itertools 0.13.0",
+ "merlin",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rayon",
@@ -9099,8 +9205,8 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -9133,7 +9239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "proc-macro2 1.0.93",
  "quote 1.0.38",
  "syn 2.0.98",
@@ -13709,14 +13815,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tiresias"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
 dependencies = [
- "crypto-bigint 0.6.0-rc.6",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
  "crypto-primes",
- "group 0.1.0",
- "homomorphic_encryption",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "homomorphic_encryption 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "merlin",
- "mpc",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rayon",
@@ -14440,24 +14546,24 @@ dependencies = [
 [[package]]
 name = "twopc_mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
 dependencies = [
  "base64 0.22.1",
  "bcs",
  "class_groups",
- "commitment",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "criterion",
- "crypto-bigint 0.6.0-rc.6",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665ad)",
  "ecdsa 0.17.0-pre.9",
  "enhanced_maurer",
  "getrandom 0.2.15",
- "group 0.1.0",
- "homomorphic_encryption",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "homomorphic_encryption 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "k256 0.14.0-pre.2",
- "maurer",
+ "maurer 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "merlin",
- "mpc",
- "proof",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "proof 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rstest 0.22.0",
@@ -14474,7 +14580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,11 +74,11 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
-mpc = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "mpc", features = ["parallel"], rev = "3a44e3e4aeca49622d1bf5fdf998683c77806eea" }
-class_groups = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "3a44e3e4aeca49622d1bf5fdf998683c77806eea", subdir = "class-groups", features = ["default", "threshold", "parallel"] }
-twopc_mpc = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "2pc-mpc", features = ["secp256k1", "bulletproofs", "paillier", "class_groups", "benchmarking"], rev = "3a44e3e4aeca49622d1bf5fdf998683c77806eea" }
-group = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "group", rev = "3a44e3e4aeca49622d1bf5fdf998683c77806eea" }
-homomorphic_encryption = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "homomorphic-encryption", rev = "3a44e3e4aeca49622d1bf5fdf998683c77806eea" }
+mpc = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "mpc", features = ["parallel"], rev = "3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78" }
+class_groups = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78", subdir = "class-groups", features = ["default", "threshold", "parallel"] }
+twopc_mpc = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "2pc-mpc", features = ["secp256k1", "bulletproofs", "paillier", "class_groups", "benchmarking"], rev = "3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78" }
+group = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "group", rev = "3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78" }
+homomorphic_encryption = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "homomorphic-encryption", rev = "3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78" }
 anyhow = "1.0.71"
 arrow = "52"
 arrow-array = "52"
@@ -560,4 +560,4 @@ include_dir = "0.7.3"
 [patch.crates-io]
 signature = { git = "https://github.com/yaelAbergel/traits", rev = "e4008c230e50f04848198f6570a4f7c9b94e503c"}
 ecdsa = { git = "https://github.com/yaelAbergel/signatures", rev = "7c8523182b1a28e5bcc6bb8d1508fbde1ea845c4"}
-crypto-bigint = { git = 'https://github.com/erik-3milabs/crypto-bigint.git', rev = '271d029' }
+crypto-bigint = { git = 'https://github.com/erik-3milabs/crypto-bigint.git', rev = '71d665ad' }

--- a/crates/dwallet-mpc-centralized-party/src/lib.rs
+++ b/crates/dwallet-mpc-centralized-party/src/lib.rs
@@ -400,7 +400,7 @@ pub fn decrypt_user_share_inner(
         .decrypt(&ciphertext, &public_parameters).into() else {
         return Err(anyhow!("Decryption failed"));
     };
-    let secret_share_bytes = crypto_bigint::U256::from(&plaintext.value())
+    let secret_share_bytes = U256::from(&plaintext.value())
         .to_be_bytes()
         .to_vec();
     Ok(secret_share_bytes)
@@ -416,7 +416,7 @@ fn cg_secp256k1_public_key_share_from_secret_share(
             &public_parameters,
         )?;
     Ok(
-        generator_group_element.scale(&crypto_bigint::Uint::<{ SCALAR_LIMBS }>::from_be_slice(
+        generator_group_element.scale(&Uint::<{ SCALAR_LIMBS }>::from_be_slice(
             &secret_key_share,
         )),
     )

--- a/crates/dwallet-mpc-centralized-party/src/lib.rs
+++ b/crates/dwallet-mpc-centralized-party/src/lib.rs
@@ -28,6 +28,7 @@ use sha3::Digest as Sha3Digest;
 use std::fmt;
 use std::marker::PhantomData;
 use log::{log, warn};
+use rand_chacha::{ChaCha20Core, ChaCha20Rng};
 use twopc_mpc::secp256k1::SCALAR_LIMBS;
 
 use class_groups_constants::protocol_public_parameters;
@@ -301,6 +302,10 @@ pub fn encrypt_secret_key_share_and_prove(
     secret_key_share: Vec<u8>,
     encryption_key: Vec<u8>,
 ) -> anyhow::Result<Vec<u8>> {
+    // Setup an RNG that works in WASM
+    let seed = [1u8;32]; // TODO: perhaps you want a better seed?
+    let mut rng = ChaCha20Rng::from(ChaCha20Core::from_seed(seed));
+
     warn!("1");
     let protocol_public_params = protocol_public_parameters();
     warn!("2");
@@ -321,7 +326,7 @@ pub fn encrypt_secret_key_share_and_prove(
             language_public_parameters
                 .encryption_scheme_public_parameters
                 .randomness_space_public_parameters(),
-            &mut OsRng,
+            &mut rng,
         )?;
     let parsed_secret_key_share = bcs::from_bytes(&secret_key_share)?;
     let witness = (parsed_secret_key_share, randomness).into();
@@ -329,7 +334,7 @@ pub fn encrypt_secret_key_share_and_prove(
         &PhantomData,
         &language_public_parameters,
         vec![witness],
-        &mut OsRng,
+        &mut rng,
     )?;
     // todo(scaly): why is it derived from statements?
     let (encryption_of_discrete_log, _) = statements.first().unwrap().clone().into();

--- a/sdk/dwallet-mpc-wasm/Cargo.lock
+++ b/sdk/dwallet-mpc-wasm/Cargo.lock
@@ -257,19 +257,19 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "class_groups"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
 dependencies = [
- "commitment",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "criterion",
- "crypto-bigint",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
  "crypto-primes",
- "group 0.1.0",
- "homomorphic_encryption",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "homomorphic_encryption 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "itertools 0.13.0",
- "maurer",
+ "maurer 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "merlin",
- "mpc",
- "proof",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "proof 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "rand",
  "rand_chacha",
  "rand_core",
@@ -289,9 +289,9 @@ dependencies = [
  "base64",
  "bcs",
  "class_groups",
- "group 0.1.0",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "log",
- "mpc",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "schemars",
  "serde",
  "twopc_mpc",
@@ -311,8 +311,20 @@ name = "commitment"
 version = "0.1.0"
 source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
 dependencies = [
- "crypto-bigint",
- "group 0.1.0",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "merlin",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "commitment"
+version = "0.1.0"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
+dependencies = [
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "merlin",
  "serde",
  "thiserror",
@@ -425,6 +437,16 @@ name = "crypto-bigint"
 version = "0.6.0-rc.6"
 source = "git+https://github.com/erik-3milabs/crypto-bigint.git?rev=271d029#271d02932e6aa93e6585ecf1cffdb34d7fecdea4"
 dependencies = [
+ "num-traits",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.6.0-rc.6"
+source = "git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a#71d665add85dfd3f9b2cbf1296c7cd31b2cbb93a"
+dependencies = [
  "hybrid-array",
  "num-traits",
  "rand_core",
@@ -460,7 +482,7 @@ version = "0.6.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9fad3f7645c77d3e0269f3e74a8dd25746de992b16bcecbb316059836e0b366"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
  "rand_core",
 ]
 
@@ -573,15 +595,15 @@ dependencies = [
  "bcs",
  "class_groups",
  "class_groups_constants",
- "commitment",
- "crypto-bigint",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=271d029)",
  "dwallet-mpc-types",
- "group 0.1.0",
- "homomorphic_encryption",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "homomorphic_encryption 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "k256",
  "log",
- "maurer",
- "mpc",
+ "maurer 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "rand_chacha",
  "rand_core",
  "schemars",
@@ -650,7 +672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc43715037532dc2d061e5c97e81b684c28993d52a4fa4eb7d2ce2826d78f2f2"
 dependencies = [
  "base16ct",
- "crypto-bigint",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
  "digest 0.11.0-pre.9",
  "ff",
  "group 0.13.0",
@@ -666,17 +688,17 @@ dependencies = [
 [[package]]
 name = "enhanced_maurer"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
 dependencies = [
- "commitment",
- "crypto-bigint",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
  "getrandom",
- "group 0.1.0",
- "homomorphic_encryption",
- "maurer",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "homomorphic_encryption 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "maurer 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "merlin",
- "mpc",
- "proof",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "proof 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "serde",
  "serde_json",
  "thiserror",
@@ -872,7 +894,25 @@ name = "group"
 version = "0.1.0"
 source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
+ "curve25519-dalek-ng",
+ "getrandom",
+ "itertools 0.13.0",
+ "k256",
+ "serde",
+ "sha3 0.11.0-pre.4",
+ "sha3 0.9.1",
+ "subtle",
+ "subtle-ng",
+ "thiserror",
+]
+
+[[package]]
+name = "group"
+version = "0.1.0"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
+dependencies = [
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
  "curve25519-dalek-ng",
  "getrandom",
  "itertools 0.13.0",
@@ -944,9 +984,21 @@ name = "homomorphic_encryption"
 version = "0.1.0"
 source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
  "getrandom",
- "group 0.1.0",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "homomorphic_encryption"
+version = "0.1.0"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
+dependencies = [
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
+ "getrandom",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "rand",
  "rand_core",
  "rstest",
@@ -1140,23 +1192,41 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "maurer"
 version = "0.1.0"
 source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
 dependencies = [
- "commitment",
- "crypto-bigint",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
  "getrandom",
- "group 0.1.0",
- "homomorphic_encryption",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "homomorphic_encryption 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
  "merlin",
- "mpc",
- "proof",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "proof 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "maurer"
+version = "0.1.0"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
+dependencies = [
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
+ "getrandom",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "homomorphic_encryption 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "merlin",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "proof 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "serde",
  "serde_json",
  "thiserror",
@@ -1219,12 +1289,28 @@ name = "mpc"
 version = "0.1.0"
 source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
 dependencies = [
- "commitment",
- "criterion",
- "crypto-bigint",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
  "gcd",
  "getrandom",
- "group 0.1.0",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "rand",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "mpc"
+version = "0.1.0"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
+dependencies = [
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "criterion",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
+ "gcd",
+ "getrandom",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "rand",
  "rand_core",
  "rayon",
@@ -1450,15 +1536,34 @@ version = "0.1.0"
 source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
 dependencies = [
  "bulletproofs",
- "commitment",
- "criterion",
- "crypto-bigint",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
  "curve25519-dalek-ng",
  "getrandom",
- "group 0.1.0",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
  "itertools 0.13.0",
  "merlin",
- "mpc",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea)",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "proof"
+version = "0.1.0"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
+dependencies = [
+ "bulletproofs",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "criterion",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
+ "curve25519-dalek-ng",
+ "getrandom",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "itertools 0.13.0",
+ "merlin",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "rand",
  "rand_core",
  "rayon",
@@ -2029,14 +2134,14 @@ dependencies = [
 [[package]]
 name = "tiresias"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
  "crypto-primes",
- "group 0.1.0",
- "homomorphic_encryption",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "homomorphic_encryption 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "merlin",
- "mpc",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "rand",
  "rand_core",
  "rayon",
@@ -2075,24 +2180,24 @@ dependencies = [
 [[package]]
 name = "twopc_mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3a44e3e4aeca49622d1bf5fdf998683c77806eea#3a44e3e4aeca49622d1bf5fdf998683c77806eea"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78#3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78"
 dependencies = [
  "base64",
  "bcs",
  "class_groups",
- "commitment",
+ "commitment 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "criterion",
- "crypto-bigint",
+ "crypto-bigint 0.6.0-rc.6 (git+https://github.com/erik-3milabs/crypto-bigint.git?rev=71d665a)",
  "ecdsa",
  "enhanced_maurer",
  "getrandom",
- "group 0.1.0",
- "homomorphic_encryption",
+ "group 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "homomorphic_encryption 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "k256",
- "maurer",
+ "maurer 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "merlin",
- "mpc",
- "proof",
+ "mpc 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
+ "proof 0.1.0 (git+https://github.com/dwallet-labs/cryptography-private?rev=3bfcc2fb18e814af9bbdf4d427b15d117f3c5e78)",
  "rand",
  "rand_core",
  "rstest",

--- a/sdk/dwallet-mpc-wasm/Cargo.toml
+++ b/sdk/dwallet-mpc-wasm/Cargo.toml
@@ -21,4 +21,4 @@ crate-type = ["cdylib"]
 
 [patch.crates-io]
 ecdsa = { git = "https://github.com/yaelAbergel/signatures", rev = "7c8523182b1a28e5bcc6bb8d1508fbde1ea845c4"}
-crypto-bigint = { git = 'https://github.com/erik-3milabs/crypto-bigint.git', rev = '271d029' }
+crypto-bigint = { git = 'https://github.com/erik-3milabs/crypto-bigint.git', rev = '71d665a' }


### PR DESCRIPTION
This PR patches the two issues that prevented 'should encrypt a secret share' from executing:
1. The `crypto-bigint` patch is updated to point to the same commit as the `cryptography-private` repository uses, and
2. replace `OsRng` with `ChaCha20`; the former uses the `getrandom` crate which is hard to compile on `wasm` targets.