### PR TITLE
fix: Allow deserializing the class groups key pair and proof when restarting the chain

### DIFF
--- a/crates/ika-config/src/node.rs
+++ b/crates/ika-config/src/node.rs
@@ -565,7 +565,6 @@ pub fn read_authority_keypair_from_file(path: &PathBuf) -> AuthorityKeyPair {
 /// Wrapper struct for ClassGroupsKeyPair that can be deserialized from a file path.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ClassGroupsKeyPairWithPath {
-    #[serde(flatten)]
     location: ClassGroupsKeyPairLocation,
 
     #[serde(skip)]
@@ -573,8 +572,6 @@ pub struct ClassGroupsKeyPairWithPath {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq)]
-#[serde_as]
-#[serde(untagged)]
 enum ClassGroupsKeyPairLocation {
     InPlace {
         value: Arc<ClassGroupsKeyPairAndProof>,

--- a/crates/ika/src/ika_commands.rs
+++ b/crates/ika/src/ika_commands.rs
@@ -326,9 +326,10 @@ async fn start(
         } else {
             let network_config: NetworkConfig = PersistedConfig::read(&network_config_path)
                 .map_err(|err| {
+                    let err_str = err.to_string();
                     err.context(format!(
-                        "Cannot open Ika network config file at {:?}",
-                        network_config_path
+                        "Cannot open Ika network config file at {:?} {:?}",
+                        network_config_path, err_str
                     ))
                 })?;
 

--- a/crates/ika/src/ika_commands.rs
+++ b/crates/ika/src/ika_commands.rs
@@ -326,10 +326,9 @@ async fn start(
         } else {
             let network_config: NetworkConfig = PersistedConfig::read(&network_config_path)
                 .map_err(|err| {
-                    let err_str = err.to_string();
                     err.context(format!(
-                        "Cannot open Ika network config file at {:?} {:?}",
-                        network_config_path, err_str
+                        "Cannot open Ika network config file at {:?}",
+                        network_config_path
                     ))
                 })?;
 


### PR DESCRIPTION
The chain restart can still fail due to another bug in the checkpointing mechanism, this PR only mitigates the class group key deserialization issue.