### PR TITLE
fix: Handle malicious behavior correctly in all flows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1753,7 +1753,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "class_groups"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "commitment",
  "crypto-bigint 0.6.0-rc.6",
@@ -1901,7 +1901,7 @@ dependencies = [
 [[package]]
 name = "commitment"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "crypto-bigint 0.6.0-rc.6",
  "group 0.1.0",
@@ -3131,7 +3131,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "enhanced_maurer"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "commitment",
  "crypto-bigint 0.6.0-rc.6",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "group"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "crypto-bigint 0.6.0-rc.6",
  "curve25519-dalek-ng",
@@ -4500,7 +4500,7 @@ dependencies = [
 [[package]]
 name = "homomorphic_encryption"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "crypto-bigint 0.6.0-rc.6",
  "getrandom 0.2.15",
@@ -6416,7 +6416,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 [[package]]
 name = "maurer"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "commitment",
  "crypto-bigint 0.6.0-rc.6",
@@ -7406,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "commitment",
  "crypto-bigint 0.6.0-rc.6",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "proof"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "bulletproofs",
  "commitment",
@@ -13690,7 +13690,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tiresias"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "crypto-bigint 0.6.0-rc.6",
  "crypto-primes",
@@ -14417,7 +14417,7 @@ dependencies = [
 [[package]]
 name = "twopc_mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "class_groups",
  "commitment",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1753,7 +1753,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "class_groups"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "commitment",
  "crypto-bigint 0.6.0-rc.6",
@@ -1901,7 +1901,7 @@ dependencies = [
 [[package]]
 name = "commitment"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "crypto-bigint 0.6.0-rc.6",
  "group 0.1.0",
@@ -3131,7 +3131,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "enhanced_maurer"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "commitment",
  "crypto-bigint 0.6.0-rc.6",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "group"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "crypto-bigint 0.6.0-rc.6",
  "curve25519-dalek-ng",
@@ -4500,7 +4500,7 @@ dependencies = [
 [[package]]
 name = "homomorphic_encryption"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "crypto-bigint 0.6.0-rc.6",
  "getrandom 0.2.15",
@@ -6416,7 +6416,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 [[package]]
 name = "maurer"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "commitment",
  "crypto-bigint 0.6.0-rc.6",
@@ -7406,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "commitment",
  "crypto-bigint 0.6.0-rc.6",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "proof"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "bulletproofs",
  "commitment",
@@ -13690,7 +13690,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tiresias"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "crypto-bigint 0.6.0-rc.6",
  "crypto-primes",
@@ -14417,7 +14417,7 @@ dependencies = [
 [[package]]
 name = "twopc_mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "class_groups",
  "commitment",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1753,7 +1753,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "class_groups"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
 dependencies = [
  "commitment",
  "crypto-bigint 0.6.0-rc.6",
@@ -1901,7 +1901,7 @@ dependencies = [
 [[package]]
 name = "commitment"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
 dependencies = [
  "crypto-bigint 0.6.0-rc.6",
  "group 0.1.0",
@@ -3131,7 +3131,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "enhanced_maurer"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
 dependencies = [
  "commitment",
  "crypto-bigint 0.6.0-rc.6",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "group"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
 dependencies = [
  "crypto-bigint 0.6.0-rc.6",
  "curve25519-dalek-ng",
@@ -4500,7 +4500,7 @@ dependencies = [
 [[package]]
 name = "homomorphic_encryption"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
 dependencies = [
  "crypto-bigint 0.6.0-rc.6",
  "getrandom 0.2.15",
@@ -6416,7 +6416,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 [[package]]
 name = "maurer"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
 dependencies = [
  "commitment",
  "crypto-bigint 0.6.0-rc.6",
@@ -7406,13 +7406,14 @@ dependencies = [
 [[package]]
 name = "mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
 dependencies = [
  "commitment",
  "crypto-bigint 0.6.0-rc.6",
  "gcd",
  "getrandom 0.2.15",
  "group 0.1.0",
+ "itertools 0.13.0",
  "rand 0.8.5",
  "rayon",
  "serde",
@@ -9010,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "proof"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
 dependencies = [
  "bulletproofs",
  "commitment",
@@ -13689,7 +13690,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tiresias"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
 dependencies = [
  "crypto-bigint 0.6.0-rc.6",
  "crypto-primes",
@@ -14416,7 +14417,7 @@ dependencies = [
 [[package]]
 name = "twopc_mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=00d0f3a#00d0f3af3c9cdb1168d37fc750e8c0701fe9ddef"
 dependencies = [
  "class_groups",
  "commitment",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,11 +75,11 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
 k256 = { git = "https://github.com/RustCrypto/elliptic-curves.git", tag = "k256/v0.14.0-pre.2", features = ["arithmetic", "critical-section", "precomputed-tables", "serde", "ecdsa", "hash2curve", "alloc"], default-features = false }
-mpc = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "mpc", rev = "00d0f3a"}
-class_groups = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "00d0f3a", subdir = "class-groups", features = ["default", "threshold", "parallel"] }
-twopc_mpc = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "2pc-mpc", features = ["secp256k1", "bulletproofs", "paillier", "class_groups"], rev = "00d0f3a"}
-group = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "group", rev = "00d0f3a"}
-homomorphic_encryption = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "homomorphic-encryption", rev = "00d0f3a"}
+mpc = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "mpc", rev = "508d952"}
+class_groups = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "508d952", subdir = "class-groups", features = ["default", "threshold", "parallel"] }
+twopc_mpc = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "2pc-mpc", features = ["secp256k1", "bulletproofs", "paillier", "class_groups"], rev = "508d952"}
+group = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "group", rev = "508d952"}
+homomorphic_encryption = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "homomorphic-encryption", rev = "508d952"}
 anyhow = "1.0.71"
 arrow = "52"
 arrow-array = "52"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,11 +75,11 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
 k256 = { git = "https://github.com/RustCrypto/elliptic-curves.git", tag = "k256/v0.14.0-pre.2", features = ["arithmetic", "critical-section", "precomputed-tables", "serde", "ecdsa", "hash2curve", "alloc"], default-features = false }
-mpc = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "mpc", rev = "508d952"}
-class_groups = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "508d952", subdir = "class-groups", features = ["default", "threshold", "parallel"] }
-twopc_mpc = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "2pc-mpc", features = ["secp256k1", "bulletproofs", "paillier", "class_groups"], rev = "508d952"}
-group = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "group", rev = "508d952"}
-homomorphic_encryption = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "homomorphic-encryption", rev = "508d952"}
+mpc = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "mpc", rev = "4f4c8d3"}
+class_groups = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "4f4c8d3", subdir = "class-groups", features = ["default", "threshold", "parallel"] }
+twopc_mpc = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "2pc-mpc", features = ["secp256k1", "bulletproofs", "paillier", "class_groups"], rev = "4f4c8d3"}
+group = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "group", rev = "4f4c8d3"}
+homomorphic_encryption = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "homomorphic-encryption", rev = "4f4c8d3"}
 anyhow = "1.0.71"
 arrow = "52"
 arrow-array = "52"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,11 +75,11 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
 k256 = { git = "https://github.com/RustCrypto/elliptic-curves.git", tag = "k256/v0.14.0-pre.2", features = ["arithmetic", "critical-section", "precomputed-tables", "serde", "ecdsa", "hash2curve", "alloc"], default-features = false }
-mpc = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "mpc", rev = "3ad27518"}
-class_groups = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "3ad27518", subdir = "class-groups", features = ["default", "threshold", "parallel"] }
-twopc_mpc = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "2pc-mpc", features = ["secp256k1", "bulletproofs", "paillier", "class_groups"], rev = "3ad27518"}
-group = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "group", rev = "3ad27518"}
-homomorphic_encryption = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "homomorphic-encryption", rev = "3ad27518"}
+mpc = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "mpc", rev = "00d0f3a"}
+class_groups = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "00d0f3a", subdir = "class-groups", features = ["default", "threshold", "parallel"] }
+twopc_mpc = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "2pc-mpc", features = ["secp256k1", "bulletproofs", "paillier", "class_groups"], rev = "00d0f3a"}
+group = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "group", rev = "00d0f3a"}
+homomorphic_encryption = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "homomorphic-encryption", rev = "00d0f3a"}
 anyhow = "1.0.71"
 arrow = "52"
 arrow-array = "52"

--- a/crates/dwallet-mpc-centralized-party/Cargo.toml
+++ b/crates/dwallet-mpc-centralized-party/Cargo.toml
@@ -6,7 +6,7 @@ version.workspace = true
 [dependencies]
 mpc.workspace = true
 twopc_mpc.workspace = true
-commitment = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "508d952", subdir = "commitment" }
+commitment = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "4f4c8d3", subdir = "commitment" }
 shared_wasm_class_groups = { path = "../shared-wasm-class-groups" }
 class_groups.workspace = true
 group.workspace = true

--- a/crates/dwallet-mpc-centralized-party/Cargo.toml
+++ b/crates/dwallet-mpc-centralized-party/Cargo.toml
@@ -6,7 +6,7 @@ version.workspace = true
 [dependencies]
 mpc.workspace = true
 twopc_mpc.workspace = true
-commitment = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "00d0f3a", subdir = "commitment" }
+commitment = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "508d952", subdir = "commitment" }
 shared_wasm_class_groups = { path = "../shared-wasm-class-groups" }
 class_groups.workspace = true
 group.workspace = true

--- a/crates/dwallet-mpc-centralized-party/Cargo.toml
+++ b/crates/dwallet-mpc-centralized-party/Cargo.toml
@@ -6,7 +6,7 @@ version.workspace = true
 [dependencies]
 mpc.workspace = true
 twopc_mpc.workspace = true
-commitment = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "3ad27518", subdir = "commitment" }
+commitment = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "00d0f3a", subdir = "commitment" }
 shared_wasm_class_groups = { path = "../shared-wasm-class-groups" }
 class_groups.workspace = true
 group.workspace = true

--- a/crates/ika-core/Cargo.toml
+++ b/crates/ika-core/Cargo.toml
@@ -18,7 +18,7 @@ homomorphic_encryption.workspace = true
 class_groups.workspace = true
 dwallet-classgroups-types.workspace = true
 schemars.workspace = true
-commitment = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "commitment", rev = "508d952"}
+commitment = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "commitment", rev = "4f4c8d3"}
 shared_wasm_class_groups = { path = "../shared-wasm-class-groups" }
 rand_core = "0.6.4"
 crypto-bigint = { workspace = true, features = ["rand_core", "serde"], default-features = false }

--- a/crates/ika-core/Cargo.toml
+++ b/crates/ika-core/Cargo.toml
@@ -18,7 +18,7 @@ homomorphic_encryption.workspace = true
 class_groups.workspace = true
 dwallet-classgroups-types.workspace = true
 schemars.workspace = true
-commitment = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "commitment", rev = "3ad27518"}
+commitment = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "commitment", rev = "00d0f3a"}
 shared_wasm_class_groups = { path = "../shared-wasm-class-groups" }
 rand_core = "0.6.4"
 crypto-bigint = { workspace = true, features = ["rand_core", "serde"], default-features = false }

--- a/crates/ika-core/Cargo.toml
+++ b/crates/ika-core/Cargo.toml
@@ -18,7 +18,7 @@ homomorphic_encryption.workspace = true
 class_groups.workspace = true
 dwallet-classgroups-types.workspace = true
 schemars.workspace = true
-commitment = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "commitment", rev = "00d0f3a"}
+commitment = { git = "https://github.com/dwallet-labs/cryptography-private", subdir = "commitment", rev = "508d952"}
 shared_wasm_class_groups = { path = "../shared-wasm-class-groups" }
 rand_core = "0.6.4"
 crypto-bigint = { workspace = true, features = ["rand_core", "serde"], default-features = false }

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -1418,9 +1418,9 @@ impl AuthorityPerEpochStore {
                         ..
                     }) => Some(DWalletMPCDBMessage::Message(message.clone())),
                     SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                        kind: ConsensusTransactionKind::DWalletMPCThresholdNotReached(report),
+                        kind: ConsensusTransactionKind::DWalletMPCThresholdNotReached(authority, report),
                         ..
-                    }) => Some(DWalletMPCDBMessage::ThresholdNotReachedReport(report.clone())),
+                    }) => Some(DWalletMPCDBMessage::ThresholdNotReachedReport(authority, report.clone())),
                     SequencedConsensusTransactionKind::External(ConsensusTransaction {
                         kind:
                             ConsensusTransactionKind::DWalletMPCMaliciousReport(

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -1064,14 +1064,9 @@ impl AuthorityPerEpochStore {
                 }
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::DWalletMPCThresholdNotReached(authority, report),
+                kind: ConsensusTransactionKind::DWalletMPCThresholdNotReached(authority, ..),
                 ..
             }) => {
-                // When sending a `DWalletMPCSessionFailedWithMalicious`,
-                // the validator also includes its public key.
-                // Here, we verify that the public key used to sign this transaction matches
-                // the provided public key.
-                // This public key is later used to identify the authority that sent the MPC message.
                 if transaction.sender_authority() != *authority {
                     warn!(
                         "DWalletMPCSessionFailedWithMalicious: authority {} does not match its author from consensus {}",

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -1064,7 +1064,7 @@ impl AuthorityPerEpochStore {
                 }
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::DWalletMPCThresholdNotReached(report),
+                kind: ConsensusTransactionKind::DWalletMPCThresholdNotReached(authority, report),
                 ..
             }) => {
                 // When sending a `DWalletMPCSessionFailedWithMalicious`,
@@ -1072,10 +1072,10 @@ impl AuthorityPerEpochStore {
                 // Here, we verify that the public key used to sign this transaction matches
                 // the provided public key.
                 // This public key is later used to identify the authority that sent the MPC message.
-                if transaction.sender_authority() != report.authority {
+                if transaction.sender_authority() != *authority {
                     warn!(
                         "DWalletMPCSessionFailedWithMalicious: authority {} does not match its author from consensus {}",
-                        report.authority, transaction.certificate_author_index
+                        authority, transaction.certificate_author_index
                     );
                     return None;
                 }
@@ -1420,7 +1420,7 @@ impl AuthorityPerEpochStore {
                     SequencedConsensusTransactionKind::External(ConsensusTransaction {
                         kind: ConsensusTransactionKind::DWalletMPCThresholdNotReached(authority, report),
                         ..
-                    }) => Some(DWalletMPCDBMessage::ThresholdNotReachedReport(authority, report.clone())),
+                    }) => Some(DWalletMPCDBMessage::ThresholdNotReachedReport(*authority, report.clone())),
                     SequencedConsensusTransactionKind::External(ConsensusTransaction {
                         kind:
                             ConsensusTransactionKind::DWalletMPCMaliciousReport(

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -1047,7 +1047,7 @@ impl AuthorityPerEpochStore {
         // Signatures are verified as part of the consensus payload verification in IkaTxValidator
         match &transaction.transaction {
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::DWalletMPCSessionFailedWithMalicious(authority, ..),
+                kind: ConsensusTransactionKind::DWalletMPCMaliciousReport(authority, ..),
                 ..
             }) => {
                 // When sending a `DWalletMPCSessionFailedWithMalicious`,
@@ -1402,7 +1402,7 @@ impl AuthorityPerEpochStore {
                     }) => Some(DWalletMPCDBMessage::Message(message.clone())),
                     SequencedConsensusTransactionKind::External(ConsensusTransaction {
                         kind:
-                            ConsensusTransactionKind::DWalletMPCSessionFailedWithMalicious(
+                            ConsensusTransactionKind::DWalletMPCMaliciousReport(
                                 authority_name,
                                 report,
                             ),
@@ -1482,7 +1482,7 @@ impl AuthorityPerEpochStore {
                 .await
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::DWalletMPCSessionFailedWithMalicious(..),
+                kind: ConsensusTransactionKind::DWalletMPCMaliciousReport(..),
                 ..
             }) => Ok(ConsensusCertificateResult::ConsensusMessage),
             SequencedConsensusTransactionKind::External(ConsensusTransaction {

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -1423,7 +1423,7 @@ impl AuthorityPerEpochStore {
                                 report,
                             ),
                         ..
-                    }) => Some(DWalletMPCDBMessage::SessionFailedWithMaliciousParties(
+                    }) => Some(DWalletMPCDBMessage::MaliciousReport(
                         authority_name.clone(),
                         report.clone(),
                     )),

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -1418,6 +1418,10 @@ impl AuthorityPerEpochStore {
                         ..
                     }) => Some(DWalletMPCDBMessage::Message(message.clone())),
                     SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                        kind: ConsensusTransactionKind::DWalletMPCThresholdNotReached(report),
+                        ..
+                    }) => Some(DWalletMPCDBMessage::ThresholdNotReachedReport(report.clone())),
+                    SequencedConsensusTransactionKind::External(ConsensusTransaction {
                         kind:
                             ConsensusTransactionKind::DWalletMPCMaliciousReport(
                                 authority_name,

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -1069,8 +1069,9 @@ impl AuthorityPerEpochStore {
             }) => {
                 if transaction.sender_authority() != *authority {
                     warn!(
-                        "DWalletMPCSessionFailedWithMalicious: authority {} does not match its author from consensus {}",
-                        authority, transaction.certificate_author_index
+                        ?authority,
+                        certificate_author_index=?transaction.certificate_author_index
+                        "DWalletMPCSessionFailedWithMalicious: authority does not match its author from consensus",
                     );
                     return None;
                 }

--- a/crates/ika-core/src/consensus_handler.rs
+++ b/crates/ika-core/src/consensus_handler.rs
@@ -532,9 +532,7 @@ pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {
         ConsensusTransactionKind::DWalletMPCMessage(..) => "dwallet_mpc_message",
         ConsensusTransactionKind::DWalletMPCOutput(..) => "dwallet_mpc_output",
         ConsensusTransactionKind::CapabilityNotificationV1(_) => "capability_notification_v1",
-        ConsensusTransactionKind::DWalletMPCMaliciousReport(..) => {
-            "dwallet_mpc_malicious_report"
-        }
+        ConsensusTransactionKind::DWalletMPCMaliciousReport(..) => "dwallet_mpc_malicious_report",
         ConsensusTransactionKind::DWalletMPCThresholdNotReached(..) => {
             "dwallet_mpc_threshold_not_reached"
         }

--- a/crates/ika-core/src/consensus_handler.rs
+++ b/crates/ika-core/src/consensus_handler.rs
@@ -531,7 +531,7 @@ pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {
         ConsensusTransactionKind::DWalletMPCMessage(..) => "dwallet_mpc_message",
         ConsensusTransactionKind::DWalletMPCOutput(..) => "dwallet_mpc_output",
         ConsensusTransactionKind::CapabilityNotificationV1(_) => "capability_notification_v1",
-        ConsensusTransactionKind::DWalletMPCSessionFailedWithMalicious(..) => {
+        ConsensusTransactionKind::DWalletMPCMaliciousReport(..) => {
             "dwallet_mpc_session_failed_with_malicious"
         }
     }

--- a/crates/ika-core/src/consensus_handler.rs
+++ b/crates/ika-core/src/consensus_handler.rs
@@ -481,7 +481,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 DWalletMPCDBMessage::Message(_)
                 | DWalletMPCDBMessage::EndOfDelivery
                 | DWalletMPCDBMessage::MPCSessionFailed(_)
-                | DWalletMPCDBMessage::SessionFailedWithMaliciousParties(..)
+                | DWalletMPCDBMessage::MaliciousReport(..)
                 | DWalletMPCDBMessage::PerformCryptographicComputations
                 | DWalletMPCDBMessage::ThresholdNotReachedReport(..) => {}
             }

--- a/crates/ika-core/src/consensus_handler.rs
+++ b/crates/ika-core/src/consensus_handler.rs
@@ -534,6 +534,9 @@ pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {
         ConsensusTransactionKind::DWalletMPCMaliciousReport(..) => {
             "dwallet_mpc_session_failed_with_malicious"
         }
+        ConsensusTransactionKind::DWalletMPCThresholdNotReached(..) => {
+            "dwallet_mpc_threshold_not_reached"
+        }
     }
 }
 

--- a/crates/ika-core/src/consensus_handler.rs
+++ b/crates/ika-core/src/consensus_handler.rs
@@ -482,7 +482,8 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 | DWalletMPCDBMessage::EndOfDelivery
                 | DWalletMPCDBMessage::MPCSessionFailed(_)
                 | DWalletMPCDBMessage::SessionFailedWithMaliciousParties(..)
-                | DWalletMPCDBMessage::PerformCryptographicComputations => {}
+                | DWalletMPCDBMessage::PerformCryptographicComputations
+                | DWalletMPCDBMessage::ThresholdNotReachedReport(..) => {}
             }
         }
         Ok(())

--- a/crates/ika-core/src/consensus_validator.rs
+++ b/crates/ika-core/src/consensus_validator.rs
@@ -69,7 +69,8 @@ impl IkaTxValidator {
                 ConsensusTransactionKind::CapabilityNotificationV1(_)
                 | ConsensusTransactionKind::DWalletMPCMessage(..)
                 | ConsensusTransactionKind::DWalletMPCOutput(..)
-                | ConsensusTransactionKind::DWalletMPCMaliciousReport(..) => {}
+                | ConsensusTransactionKind::DWalletMPCMaliciousReport(..)
+                | ConsensusTransactionKind::DWalletMPCThresholdNotReached(..) => {}
             }
         }
 

--- a/crates/ika-core/src/consensus_validator.rs
+++ b/crates/ika-core/src/consensus_validator.rs
@@ -69,7 +69,7 @@ impl IkaTxValidator {
                 ConsensusTransactionKind::CapabilityNotificationV1(_)
                 | ConsensusTransactionKind::DWalletMPCMessage(..)
                 | ConsensusTransactionKind::DWalletMPCOutput(..)
-                | ConsensusTransactionKind::DWalletMPCSessionFailedWithMalicious(..) => {}
+                | ConsensusTransactionKind::DWalletMPCMaliciousReport(..) => {}
             }
         }
 

--- a/crates/ika-core/src/dwallet_mpc/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/mod.rs
@@ -451,7 +451,7 @@ pub(crate) fn advance_and_serialize<P: AsynchronouslyAdvanceable>(
 }
 
 struct DeserializeMPCMessagesResponse<M: DeserializeOwned + Clone> {
-    messages: Vec<HashMap<PartyID, M>>,
+    messages: HashMap<usize, HashMap<PartyID, M>>,
     malicious_parties: Vec<PartyID>,
 }
 
@@ -461,10 +461,10 @@ struct DeserializeMPCMessagesResponse<M: DeserializeOwned + Clone> {
 fn deserialize_mpc_messages<M: DeserializeOwned + Clone>(
     messages: Vec<HashMap<PartyID, MPCMessage>>,
 ) -> DeserializeMPCMessagesResponse<M> {
-    let mut deserialized_results = Vec::new();
+    let mut deserialized_results = HashMap::new();
     let mut malicious_parties = Vec::new();
 
-    for message_batch in &messages {
+    for (index, message_batch) in &messages.iter().enumerate() {
         let mut valid_messages = HashMap::new();
 
         for (party_id, message) in message_batch {
@@ -484,7 +484,7 @@ fn deserialize_mpc_messages<M: DeserializeOwned + Clone>(
         }
 
         if !valid_messages.is_empty() {
-            deserialized_results.push(valid_messages);
+            deserialized_results.insert(index + 1, valid_messages);
         }
     }
     DeserializeMPCMessagesResponse {

--- a/crates/ika-core/src/dwallet_mpc/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/mod.rs
@@ -396,7 +396,7 @@ pub(crate) fn advance_and_serialize<P: AsynchronouslyAdvanceable>(
         malicious_parties: _,
     } = deserialize_mpc_messages(messages);
 
-    let res = match P::advance(
+    let res = match P::advance_with_guaranteed_output(
         session_id,
         party_id,
         access_threshold,

--- a/crates/ika-core/src/dwallet_mpc/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/mod.rs
@@ -484,7 +484,7 @@ fn deserialize_mpc_messages<M: DeserializeOwned + Clone>(
         }
 
         if !valid_messages.is_empty() {
-            deserialized_results.insert(index + 1, valid_messages);
+            deserialized_results.insert(index, valid_messages);
         }
     }
     DeserializeMPCMessagesResponse {

--- a/crates/ika-core/src/dwallet_mpc/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/mod.rs
@@ -416,7 +416,7 @@ pub(crate) fn advance_and_serialize<P: AsynchronouslyAdvanceable>(
             return match e.into() {
                 // No threshold was reached, so we can't proceed.
                 mpc::Error::ThresholdNotReached => {
-                    todo!("Handle threshold not reached error")
+                    return Err(DwalletMPCError::TWOPCMPCThresholdNotReached)
                 }
                 _ => Err(general_error),
             };

--- a/crates/ika-core/src/dwallet_mpc/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/mod.rs
@@ -415,17 +415,8 @@ pub(crate) fn advance_and_serialize<P: AsynchronouslyAdvanceable>(
             ));
             return match e.into() {
                 // No threshold was reached, so we can't proceed.
-                mpc::Error::ThresholdNotReached { honest_subset } => {
-                    let malicious_actors = messages
-                        .last()
-                        .ok_or(general_error)?
-                        .keys()
-                        .filter(|party_id| !honest_subset.contains(*party_id))
-                        .cloned()
-                        .collect();
-                    Err(DwalletMPCError::SessionFailedWithMaliciousParties(
-                        malicious_actors,
-                    ))
+                mpc::Error::ThresholdNotReached => {
+                    todo!("Handle threshold not reached error")
                 }
                 _ => Err(general_error),
             };

--- a/crates/ika-core/src/dwallet_mpc/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/mod.rs
@@ -464,7 +464,7 @@ fn deserialize_mpc_messages<M: DeserializeOwned + Clone>(
     let mut deserialized_results = HashMap::new();
     let mut malicious_parties = Vec::new();
 
-    for (index, message_batch) in &messages.iter().enumerate() {
+    for (index, message_batch) in messages.iter().enumerate() {
         let mut valid_messages = HashMap::new();
 
         for (party_id, message) in message_batch {

--- a/crates/ika-core/src/dwallet_mpc/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/mod.rs
@@ -396,6 +396,8 @@ pub(crate) fn advance_and_serialize<P: AsynchronouslyAdvanceable>(
         malicious_parties: _,
     } = deserialize_mpc_messages(messages);
 
+    // When a `ThresholdNotReached` error is received, the system now waits for additional messages
+    // (including those from previous rounds) and retries.
     let res = match P::advance_with_guaranteed_output(
         session_id,
         party_id,
@@ -451,6 +453,7 @@ pub(crate) fn advance_and_serialize<P: AsynchronouslyAdvanceable>(
 }
 
 struct DeserializeMPCMessagesResponse<M: DeserializeOwned + Clone> {
+    /// round -> {party -> message}
     messages: HashMap<usize, HashMap<PartyID, M>>,
     malicious_parties: Vec<PartyID>,
 }

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -324,7 +324,6 @@ impl DWalletMPCManager {
 
     fn wait_for_more_messages_and_retry(&mut self, session_id: ObjectID) {
         if let Some(session) = self.mpc_sessions.get_mut(&session_id) {
-            session.received_more_messages_since_last_retry = false;
             session.attempts_count += 1;
             session.pending_quorum_for_highest_round_number -= 1;
         }
@@ -526,6 +525,7 @@ impl DWalletMPCManager {
             .filter_map(|(_, ref mut session)| {
                 let quorum_check_result = session.check_quorum_for_next_crypto_round();
                 if quorum_check_result.is_ready {
+                    session.received_more_messages_since_last_advance = false;
                     // We must first clone the session, as we approve to advance the current session
                     // in the current round and then start waiting for the next round's messages
                     // until it is ready to advance or finalized.

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -38,13 +38,7 @@ use ika_types::crypto::DefaultHash;
 use ika_types::digests::Digest;
 use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use ika_types::messages_consensus::ConsensusTransaction;
-use ika_types::messages_dwallet_mpc::{
-    AdvanceResult, DBSuiEvent, DWalletDecryptionKeyReshareRequestEvent, DWalletMPCEvent,
-    DWalletMPCEventTrait, DWalletMPCMessage, DWalletMPCSuiEvent, MPCProtocolInitData,
-    MaliciousReport, SessionInfo, SessionType, StartDKGFirstRoundEvent, StartDKGSecondRoundEvent,
-    StartEncryptedShareVerificationEvent, StartNetworkDKGEvent,
-    StartPartialSignaturesVerificationEvent, StartPresignFirstRoundEvent, StartSignEvent,
-};
+use ika_types::messages_dwallet_mpc::{AdvanceResult, DBSuiEvent, DWalletDecryptionKeyReshareRequestEvent, DWalletMPCEvent, DWalletMPCEventTrait, DWalletMPCMessage, DWalletMPCSuiEvent, MPCProtocolInitData, MaliciousReport, SessionInfo, SessionType, StartDKGFirstRoundEvent, StartDKGSecondRoundEvent, StartEncryptedShareVerificationEvent, StartNetworkDKGEvent, StartPartialSignaturesVerificationEvent, StartPresignFirstRoundEvent, StartSignEvent, ThresholdNotReachedReport};
 use itertools::Itertools;
 use mpc::WeightedThresholdAccessStructure;
 use serde::{Deserialize, Serialize};
@@ -130,6 +124,7 @@ pub enum DWalletMPCDBMessage {
     /// and re-run the round again to make it succeed.
     /// AuthorityName is the name of the authority that reported the malicious parties.
     SessionFailedWithMaliciousParties(AuthorityName, MaliciousReport),
+    ThresholdNotReachedReport(ThresholdNotReachedReport),
 }
 
 struct ReadySessionsResponse {

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -38,7 +38,14 @@ use ika_types::crypto::DefaultHash;
 use ika_types::digests::Digest;
 use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use ika_types::messages_consensus::ConsensusTransaction;
-use ika_types::messages_dwallet_mpc::{AdvanceResult, DBSuiEvent, DWalletDecryptionKeyReshareRequestEvent, DWalletMPCEvent, DWalletMPCEventTrait, DWalletMPCMessage, DWalletMPCSuiEvent, MPCProtocolInitData, MaliciousReport, SessionInfo, SessionType, StartDKGFirstRoundEvent, StartDKGSecondRoundEvent, StartEncryptedShareVerificationEvent, StartNetworkDKGEvent, StartPartialSignaturesVerificationEvent, StartPresignFirstRoundEvent, StartSignEvent, ThresholdNotReachedReport};
+use ika_types::messages_dwallet_mpc::{
+    AdvanceResult, DBSuiEvent, DWalletDecryptionKeyReshareRequestEvent, DWalletMPCEvent,
+    DWalletMPCEventTrait, DWalletMPCMessage, DWalletMPCSuiEvent, MPCProtocolInitData,
+    MaliciousReport, SessionInfo, SessionType, StartDKGFirstRoundEvent, StartDKGSecondRoundEvent,
+    StartEncryptedShareVerificationEvent, StartNetworkDKGEvent,
+    StartPartialSignaturesVerificationEvent, StartPresignFirstRoundEvent, StartSignEvent,
+    ThresholdNotReachedReport,
+};
 use itertools::Itertools;
 use mpc::WeightedThresholdAccessStructure;
 use serde::{Deserialize, Serialize};
@@ -279,6 +286,7 @@ impl DWalletMPCManager {
                     );
                 }
             }
+            DWalletMPCDBMessage::ThresholdNotReachedReport(_) => {}
         }
     }
 

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -286,7 +286,7 @@ impl DWalletMPCManager {
                     );
                 }
             }
-            DWalletMPCDBMessage::ThresholdNotReachedReport(_) => {}
+            DWalletMPCDBMessage::ThresholdNotReachedReport(..) => {}
         }
     }
 

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -318,7 +318,6 @@ impl DWalletMPCManager {
             .is_quorum_reached()
         {
             self.wait_for_more_messages_and_retry(report.session_id);
-            self.threshold_not_reached_reports.remove(&report);
         }
         Ok(())
     }

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -323,6 +323,7 @@ impl DWalletMPCManager {
     fn wait_for_more_messages_and_retry(&mut self, session_id: ObjectID) {
         if let Some(session) = self.mpc_sessions.get_mut(&session_id) {
             session.received_more_messages_since_last_retry = false;
+            session.attempts_count += 1;
             session.pending_quorum_for_highest_round_number -= 1;
         }
     }

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -306,11 +306,12 @@ impl DWalletMPCManager {
         report: ThresholdNotReachedReport,
         origin_authority: AuthorityName,
     ) -> DwalletMPCResult<()> {
+        let committee = self.epoch_store()?.committee().clone();
         if self
             .threshold_not_reached_reports
             .entry(report.clone())
             .or_insert(StakeAggregator::new(
-                self.epoch_store()?.committee().clone(),
+                committee,
             ))
             .insert_generic(origin_authority, ())
             .is_quorum_reached()

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -133,7 +133,7 @@ pub enum DWalletMPCDBMessage {
     /// We can receive new messages for this session with other validators
     /// and re-run the round again to make it succeed.
     /// AuthorityName is the name of the authority that reported the malicious parties.
-    SessionFailedWithMaliciousParties(AuthorityName, MaliciousReport),
+    MaliciousReport(AuthorityName, MaliciousReport),
     ThresholdNotReachedReport(AuthorityName, ThresholdNotReachedReport),
 }
 
@@ -280,10 +280,8 @@ impl DWalletMPCManager {
                 error!(session_id=?session_id, "dwallet MPC session failed");
                 // TODO (#524): Handle failed MPC sessions
             }
-            DWalletMPCDBMessage::SessionFailedWithMaliciousParties(authority_name, report) => {
-                if let Err(err) = self
-                    .handle_session_failed_with_malicious_parties_message(authority_name, report)
-                {
+            DWalletMPCDBMessage::MaliciousReport(authority_name, report) => {
+                if let Err(err) = self.handle_malicious_report(authority_name, report) {
                     error!(
                         "dWallet MPC session failed with malicious parties with error: {:?}",
                         err
@@ -343,7 +341,7 @@ impl DWalletMPCManager {
         Ok(())
     }
 
-    fn handle_session_failed_with_malicious_parties_message(
+    fn handle_malicious_report(
         &mut self,
         reporting_authority: AuthorityName,
         report: MaliciousReport,

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -310,9 +310,7 @@ impl DWalletMPCManager {
         if self
             .threshold_not_reached_reports
             .entry(report.clone())
-            .or_insert(StakeAggregator::new(
-                committee,
-            ))
+            .or_insert(StakeAggregator::new(committee))
             .insert_generic(origin_authority, ())
             .is_quorum_reached()
         {

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -305,10 +305,15 @@ impl DWalletMPCManager {
         origin_authority: AuthorityName,
     ) -> DwalletMPCResult<()> {
         let committee = self.epoch_store()?.committee().clone();
-        if self
+        let current_voters_for_report = self
             .threshold_not_reached_reports
             .entry(report.clone())
-            .or_insert(StakeAggregator::new(committee))
+            .or_insert(StakeAggregator::new(committee));
+        if current_voters_for_report.has_quorum() {
+            // do nothing, quorum has already been reached
+            return Ok(());
+        }
+        if current_voters_for_report
             .insert_generic(origin_authority, ())
             .is_quorum_reached()
         {

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -131,7 +131,7 @@ pub enum DWalletMPCDBMessage {
     /// and re-run the round again to make it succeed.
     /// AuthorityName is the name of the authority that reported the malicious parties.
     SessionFailedWithMaliciousParties(AuthorityName, MaliciousReport),
-    ThresholdNotReachedReport(ThresholdNotReachedReport),
+    ThresholdNotReachedReport(AuthorityName, ThresholdNotReachedReport),
 }
 
 struct ReadySessionsResponse {

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -129,11 +129,12 @@ pub enum DWalletMPCDBMessage {
     /// This message is being sent every five seconds by the dWallet MPC Service,
     /// to skip redundant advancements that have already been completed by other validators.
     PerformCryptographicComputations,
-    /// A message indicating that a session failed due to malicious parties.
-    /// We can receive new messages for this session with other validators
-    /// and re-run the round again to make it succeed.
+
+    /// A message that continas a [`MaliciousReport`] after an advance/finalize.
     /// AuthorityName is the name of the authority that reported the malicious parties.
     MaliciousReport(AuthorityName, MaliciousReport),
+    /// A meesage indicating that some of the parteis were malicous,
+    /// but we can still retry once we recieve more messages.
     ThresholdNotReachedReport(AuthorityName, ThresholdNotReachedReport),
 }
 
@@ -283,16 +284,16 @@ impl DWalletMPCManager {
             DWalletMPCDBMessage::MaliciousReport(authority_name, report) => {
                 if let Err(err) = self.handle_malicious_report(authority_name, report) {
                     error!(
-                        "dWallet MPC session failed with malicious parties with error: {:?}",
-                        err
+                        ?err,
+                        "dWallet MPC session failed with malicious parties with error",
                     );
                 }
             }
             DWalletMPCDBMessage::ThresholdNotReachedReport(authority, report) => {
                 if let Err(err) = self.handle_threshold_not_reached_report(report, authority) {
                     error!(
-                        "dWallet MPC session failed with threshold not reached with error: {:?}",
-                        err
+                        ?err,
+                        "dWallet MPC session failed — threshold not reached with error",
                     );
                 }
             }
@@ -309,20 +310,22 @@ impl DWalletMPCManager {
             .threshold_not_reached_reports
             .entry(report.clone())
             .or_insert(StakeAggregator::new(committee));
+        // We already have a quorum for this report.
         if current_voters_for_report.has_quorum() {
-            // do nothing, quorum has already been reached
+            // Do nothing, quorum has already been reached
             return Ok(());
         }
         if current_voters_for_report
             .insert_generic(origin_authority, ())
             .is_quorum_reached()
         {
-            self.wait_for_more_messages_and_retry(report.session_id);
+            self.prepare_for_round_retry(report.session_id);
         }
         Ok(())
     }
 
-    fn wait_for_more_messages_and_retry(&mut self, session_id: ObjectID) {
+    /// Change the session data to make the last round retry possible.
+    fn prepare_for_round_retry(&mut self, session_id: ObjectID) {
         if let Some(session) = self.mpc_sessions.get_mut(&session_id) {
             session.attempts_count += 1;
             session.pending_quorum_for_highest_round_number -= 1;

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -201,50 +201,50 @@ impl DWalletMPCSession {
                 Ok(())
             }
             Err(DwalletMPCError::TWOPCMPCThresholdNotReached) => {
-                let base64_mpc_messages = general_purpose::STANDARD
-                    .encode(bcs::to_bytes(&self.serialized_full_messages)?);
-                let mpc_event_data = self.mpc_event_data.clone().unwrap();
-                let base64_mpc_public_input =
-                    general_purpose::STANDARD.encode(bcs::to_bytes(&mpc_event_data.public_input)?);
-                let base64_mpc_init_protocol_data = general_purpose::STANDARD
-                    .encode(bcs::to_bytes(&mpc_event_data.init_protocol_data)?);
-                let base64_mpc_session_type =
-                    general_purpose::STANDARD.encode(bcs::to_bytes(&mpc_event_data.session_type)?);
+                // let base64_mpc_messages = general_purpose::STANDARD
+                //     .encode(bcs::to_bytes(&self.serialized_full_messages)?);
+                // let mpc_event_data = self.mpc_event_data.clone().unwrap();
+                // let base64_mpc_public_input =
+                //     general_purpose::STANDARD.encode(bcs::to_bytes(&mpc_event_data.public_input)?);
+                // let base64_mpc_init_protocol_data = general_purpose::STANDARD
+                //     .encode(bcs::to_bytes(&mpc_event_data.init_protocol_data)?);
+                // let base64_mpc_session_type =
+                //     general_purpose::STANDARD.encode(bcs::to_bytes(&mpc_event_data.session_type)?);
                 error!(
-                    messages=?base64_mpc_messages,
-                    public_input=?base64_mpc_public_input,
-                    init_protocol_data=?base64_mpc_init_protocol_data,
-                    session_type=?base64_mpc_session_type,
-                    session_id=?self.session_id,
-                    validator=?self.epoch_store()?.name,
-                    crypto_round=?self.pending_quorum_for_highest_round_number,
-                    party_id=?self.party_id,
+                    // messages=?base64_mpc_messages,
+                    // public_input=?base64_mpc_public_input,
+                    // init_protocol_data=?base64_mpc_init_protocol_data,
+                    // session_type=?base64_mpc_session_type,
+                    // session_id=?self.session_id,
+                    // validator=?self.epoch_store()?.name,
+                    // crypto_round=?self.pending_quorum_for_highest_round_number,
+                    // party_id=?self.party_id,
                     "MPC session failed"
                 );
                 self.report_threshold_not_reached(tokio_runtime_handle)
             }
             Err(err) => {
                 error!(?err, "failed to advance the MPC session");
-                let base64_mpc_messages = general_purpose::STANDARD
-                    .encode(bcs::to_bytes(&self.serialized_full_messages)?);
-                let mpc_event_data = self.mpc_event_data.clone().unwrap();
-                let base64_mpc_public_input =
-                    general_purpose::STANDARD.encode(bcs::to_bytes(&mpc_event_data.public_input)?);
-                let base64_mpc_init_protocol_data = general_purpose::STANDARD
-                    .encode(bcs::to_bytes(&mpc_event_data.init_protocol_data)?);
-                let base64_mpc_session_type =
-                    general_purpose::STANDARD.encode(bcs::to_bytes(&mpc_event_data.session_type)?);
-                error!(
-                    messages=?base64_mpc_messages,
-                    public_input=?base64_mpc_public_input,
-                    init_protocol_data=?base64_mpc_init_protocol_data,
-                    session_type=?base64_mpc_session_type,
-                    session_id=?self.session_id,
-                    validator=?self.epoch_store()?.name,
-                    crypto_round=?self.pending_quorum_for_highest_round_number,
-                    party_id=?self.party_id,
-                    "MPC session failed"
-                );
+                // let base64_mpc_messages = general_purpose::STANDARD
+                //     .encode(bcs::to_bytes(&self.serialized_full_messages)?);
+                // let mpc_event_data = self.mpc_event_data.clone().unwrap();
+                // let base64_mpc_public_input =
+                //     general_purpose::STANDARD.encode(bcs::to_bytes(&mpc_event_data.public_input)?);
+                // let base64_mpc_init_protocol_data = general_purpose::STANDARD
+                //     .encode(bcs::to_bytes(&mpc_event_data.init_protocol_data)?);
+                // let base64_mpc_session_type =
+                //     general_purpose::STANDARD.encode(bcs::to_bytes(&mpc_event_data.session_type)?);
+                // error!(
+                //     messages=?base64_mpc_messages,
+                //     public_input=?base64_mpc_public_input,
+                //     init_protocol_data=?base64_mpc_init_protocol_data,
+                //     session_type=?base64_mpc_session_type,
+                //     session_id=?self.session_id,
+                //     validator=?self.epoch_store()?.name,
+                //     crypto_round=?self.pending_quorum_for_highest_round_number,
+                //     party_id=?self.party_id,
+                //     "MPC session failed"
+                // );
 
                 let consensus_adapter = self.consensus_adapter.clone();
                 let epoch_store = self.epoch_store()?.clone();

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -88,6 +88,7 @@ pub(super) struct DWalletMPCSession {
     weighted_threshold_access_structure: WeightedThresholdAccessStructure,
     pub(crate) mpc_event_data: Option<MPCEventData>,
     pub(crate) received_more_messages_since_last_retry: bool,
+    pub(crate) attempts_count: usize,
 }
 
 impl DWalletMPCSession {
@@ -113,6 +114,7 @@ impl DWalletMPCSession {
             weighted_threshold_access_structure,
             mpc_event_data,
             received_more_messages_since_last_retry: false,
+            attempts_count: 0,
         }
     }
 
@@ -314,6 +316,7 @@ impl DWalletMPCSession {
             self.new_dwallet_report_threshold_not_reached(ThresholdNotReachedReport {
                 session_id: self.session_id,
                 crypto_round_number: self.pending_quorum_for_highest_round_number,
+                attempt: self.attempts_count,
             })?;
         let epoch_store = self.epoch_store()?.clone();
         let consensus_adapter = self.consensus_adapter.clone();

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -320,7 +320,6 @@ impl DWalletMPCSession {
             self.new_dwallet_report_threshold_not_reached(ThresholdNotReachedReport {
                 session_id: self.session_id,
                 crypto_round_number: self.pending_quorum_for_highest_round_number,
-                authority: self.epoch_store()?.name,
             })?;
         let epoch_store = self.epoch_store()?.clone();
         let consensus_adapter = self.consensus_adapter.clone();
@@ -537,7 +536,12 @@ impl DWalletMPCSession {
         &self,
         report: ThresholdNotReachedReport,
     ) -> DwalletMPCResult<ConsensusTransaction> {
-        Ok(ConsensusTransaction::new_dwallet_mpc_session_threshold_not_reached(report))
+        Ok(
+            ConsensusTransaction::new_dwallet_mpc_session_threshold_not_reached(
+                self.epoch_store()?.name,
+                report,
+            ),
+        )
     }
 
     /// Stores a message in the serialized messages map.

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -478,15 +478,7 @@ impl DWalletMPCSession {
                     &self.weighted_threshold_access_structure,
                     self.serialized_full_messages.clone(),
                     public_input,
-                    (
-                        bcs::from_bytes(
-                            &mpc_event_data
-                                .private_input
-                                .clone()
-                                .ok_or(DwalletMPCError::MissingMPCPrivateInput)?,
-                        )?,
-                        decryption_key_shares,
-                    ),
+                    decryption_key_shares,
                 )
             }
             _ => {

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -201,50 +201,50 @@ impl DWalletMPCSession {
                 Ok(())
             }
             Err(DwalletMPCError::TWOPCMPCThresholdNotReached) => {
-                // let base64_mpc_messages = general_purpose::STANDARD
-                //     .encode(bcs::to_bytes(&self.serialized_full_messages)?);
-                // let mpc_event_data = self.mpc_event_data.clone().unwrap();
-                // let base64_mpc_public_input =
-                //     general_purpose::STANDARD.encode(bcs::to_bytes(&mpc_event_data.public_input)?);
-                // let base64_mpc_init_protocol_data = general_purpose::STANDARD
-                //     .encode(bcs::to_bytes(&mpc_event_data.init_protocol_data)?);
-                // let base64_mpc_session_type =
-                //     general_purpose::STANDARD.encode(bcs::to_bytes(&mpc_event_data.session_type)?);
+                let base64_mpc_messages = general_purpose::STANDARD
+                    .encode(bcs::to_bytes(&self.serialized_full_messages)?);
+                let mpc_event_data = self.mpc_event_data.clone().unwrap();
+                let base64_mpc_public_input =
+                    general_purpose::STANDARD.encode(bcs::to_bytes(&mpc_event_data.public_input)?);
+                let base64_mpc_init_protocol_data = general_purpose::STANDARD
+                    .encode(bcs::to_bytes(&mpc_event_data.init_protocol_data)?);
+                let base64_mpc_session_type =
+                    general_purpose::STANDARD.encode(bcs::to_bytes(&mpc_event_data.session_type)?);
                 error!(
-                    // messages=?base64_mpc_messages,
-                    // public_input=?base64_mpc_public_input,
-                    // init_protocol_data=?base64_mpc_init_protocol_data,
-                    // session_type=?base64_mpc_session_type,
-                    // session_id=?self.session_id,
-                    // validator=?self.epoch_store()?.name,
-                    // crypto_round=?self.pending_quorum_for_highest_round_number,
-                    // party_id=?self.party_id,
+                    messages=?base64_mpc_messages,
+                    public_input=?base64_mpc_public_input,
+                    init_protocol_data=?base64_mpc_init_protocol_data,
+                    session_type=?base64_mpc_session_type,
+                    session_id=?self.session_id,
+                    validator=?self.epoch_store()?.name,
+                    crypto_round=?self.pending_quorum_for_highest_round_number,
+                    party_id=?self.party_id,
                     "MPC session failed"
                 );
                 self.report_threshold_not_reached(tokio_runtime_handle)
             }
             Err(err) => {
                 error!(?err, "failed to advance the MPC session");
-                // let base64_mpc_messages = general_purpose::STANDARD
-                //     .encode(bcs::to_bytes(&self.serialized_full_messages)?);
-                // let mpc_event_data = self.mpc_event_data.clone().unwrap();
-                // let base64_mpc_public_input =
-                //     general_purpose::STANDARD.encode(bcs::to_bytes(&mpc_event_data.public_input)?);
-                // let base64_mpc_init_protocol_data = general_purpose::STANDARD
-                //     .encode(bcs::to_bytes(&mpc_event_data.init_protocol_data)?);
-                // let base64_mpc_session_type =
-                //     general_purpose::STANDARD.encode(bcs::to_bytes(&mpc_event_data.session_type)?);
-                // error!(
-                //     messages=?base64_mpc_messages,
-                //     public_input=?base64_mpc_public_input,
-                //     init_protocol_data=?base64_mpc_init_protocol_data,
-                //     session_type=?base64_mpc_session_type,
-                //     session_id=?self.session_id,
-                //     validator=?self.epoch_store()?.name,
-                //     crypto_round=?self.pending_quorum_for_highest_round_number,
-                //     party_id=?self.party_id,
-                //     "MPC session failed"
-                // );
+                let base64_mpc_messages = general_purpose::STANDARD
+                    .encode(bcs::to_bytes(&self.serialized_full_messages)?);
+                let mpc_event_data = self.mpc_event_data.clone().unwrap();
+                let base64_mpc_public_input =
+                    general_purpose::STANDARD.encode(bcs::to_bytes(&mpc_event_data.public_input)?);
+                let base64_mpc_init_protocol_data = general_purpose::STANDARD
+                    .encode(bcs::to_bytes(&mpc_event_data.init_protocol_data)?);
+                let base64_mpc_session_type =
+                    general_purpose::STANDARD.encode(bcs::to_bytes(&mpc_event_data.session_type)?);
+                error!(
+                    messages=?base64_mpc_messages,
+                    public_input=?base64_mpc_public_input,
+                    init_protocol_data=?base64_mpc_init_protocol_data,
+                    session_type=?base64_mpc_session_type,
+                    session_id=?self.session_id,
+                    validator=?self.epoch_store()?.name,
+                    crypto_round=?self.pending_quorum_for_highest_round_number,
+                    party_id=?self.party_id,
+                    "MPC session failed"
+                );
 
                 let consensus_adapter = self.consensus_adapter.clone();
                 let epoch_store = self.epoch_store()?.clone();

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -88,6 +88,8 @@ pub(super) struct DWalletMPCSession {
     weighted_threshold_access_structure: WeightedThresholdAccessStructure,
     pub(crate) mpc_event_data: Option<MPCEventData>,
     pub(crate) received_more_messages_since_last_retry: bool,
+    // The *total* number of attempts to advance that failed in the session. 
+    // Used to make `ThresholdNotReachedReport` unique.
     pub(crate) attempts_count: usize,
 }
 

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -219,11 +219,6 @@ impl DWalletMPCSession {
                     party_id=?self.party_id,
                     "MPC session failed"
                 );
-                // self.report_malicious_actors(
-                //     tokio_runtime_handle,
-                //     malicious_parties,
-                //     AdvanceResult::Failure,
-                // )
                 self.report_threshold_not_reached(tokio_runtime_handle)
             }
             Err(err) => {

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -195,7 +195,7 @@ impl DWalletMPCSession {
                 });
                 Ok(())
             }
-            Err(DwalletMPCError::SessionFailedWithMaliciousParties(malicious_parties)) => {
+            Err(DwalletMPCError::TWOPCMPCThresholdNotReached(malicious_parties)) => {
                 error!(?malicious_parties, "session failed with malicious parties",);
                 let base64_mpc_messages = general_purpose::STANDARD
                     .encode(bcs::to_bytes(&self.serialized_full_messages)?);

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -33,7 +33,11 @@ use ika_types::committee::StakeUnit;
 use ika_types::crypto::AuthorityName;
 use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use ika_types::messages_consensus::ConsensusTransaction;
-use ika_types::messages_dwallet_mpc::{AdvanceResult, DWalletMPCMessage, MPCProtocolInitData, MaliciousReport, PresignSessionState, SessionInfo, SessionType, StartEncryptedShareVerificationEvent, StartPresignFirstRoundEvent, ThresholdNotReachedReport};
+use ika_types::messages_dwallet_mpc::{
+    AdvanceResult, DWalletMPCMessage, MPCProtocolInitData, MaliciousReport, PresignSessionState,
+    SessionInfo, SessionType, StartEncryptedShareVerificationEvent, StartPresignFirstRoundEvent,
+    ThresholdNotReachedReport,
+};
 use sui_types::base_types::{EpochId, ObjectID};
 use sui_types::id::ID;
 
@@ -311,15 +315,13 @@ impl DWalletMPCSession {
     /// In the Sign-Identifiable Abort protocol, each validator sends a malicious report, even
     /// if no malicious actors are found. This is necessary to reach agreement on a malicious report
     /// and to punish the validator who started the Sign IA report if they sent a faulty report.
-    fn report_threshold_not_reached(
-        &self,
-        tokio_runtime_handle: &Handle,
-    ) -> DwalletMPCResult<()> {
-        let report_tx = self.new_dwallet_report_threshold_not_reached(ThresholdNotReachedReport {
-            session_id: self.session_id,
-            crypto_round_number: self.pending_quorum_for_highest_round_number,
-            authority: self.epoch_store()?.name,
-        })?;
+    fn report_threshold_not_reached(&self, tokio_runtime_handle: &Handle) -> DwalletMPCResult<()> {
+        let report_tx =
+            self.new_dwallet_report_threshold_not_reached(ThresholdNotReachedReport {
+                session_id: self.session_id,
+                crypto_round_number: self.pending_quorum_for_highest_round_number,
+                authority: self.epoch_store()?.name,
+            })?;
         let epoch_store = self.epoch_store()?.clone();
         let consensus_adapter = self.consensus_adapter.clone();
         tokio_runtime_handle.spawn(async move {
@@ -535,11 +537,7 @@ impl DWalletMPCSession {
         &self,
         report: ThresholdNotReachedReport,
     ) -> DwalletMPCResult<ConsensusTransaction> {
-        Ok(
-            ConsensusTransaction::new_dwallet_mpc_session_threshold_not_reached(
-                report,
-            ),
-        )
+        Ok(ConsensusTransaction::new_dwallet_mpc_session_threshold_not_reached(report))
     }
 
     /// Stores a message in the serialized messages map.

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -87,6 +87,7 @@ pub(super) struct DWalletMPCSession {
     // TODO (#539): Simplify struct to only contain session related data - remove this field.
     weighted_threshold_access_structure: WeightedThresholdAccessStructure,
     pub(crate) mpc_event_data: Option<MPCEventData>,
+    pub(crate) received_more_messages_since_last_retry: bool,
 }
 
 impl DWalletMPCSession {
@@ -111,6 +112,7 @@ impl DWalletMPCSession {
             party_id,
             weighted_threshold_access_structure,
             mpc_event_data,
+            received_more_messages_since_last_retry: false,
         }
     }
 

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -523,9 +523,6 @@ impl DWalletMPCSession {
         )
     }
 
-    /// Report that the session failed because of malicious actors.
-    /// Once a quorum of validators reports the same actor, it is considered malicious.
-    /// The session will be continued, and the malicious actors will be ignored.
     fn new_dwallet_report_threshold_not_reached(
         &self,
         report: ThresholdNotReachedReport,

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -309,9 +309,6 @@ impl DWalletMPCSession {
         Ok(())
     }
 
-    /// In the Sign-Identifiable Abort protocol, each validator sends a malicious report, even
-    /// if no malicious actors are found. This is necessary to reach agreement on a malicious report
-    /// and to punish the validator who started the Sign IA report if they sent a faulty report.
     fn report_threshold_not_reached(&self, tokio_runtime_handle: &Handle) -> DwalletMPCResult<()> {
         let report_tx =
             self.new_dwallet_report_threshold_not_reached(ThresholdNotReachedReport {

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -643,7 +643,7 @@ impl DWalletMPCSession {
         match self.status {
             MPCSessionStatus::Active => {
                 if self.pending_quorum_for_highest_round_number == 0
-                    || self
+                    || (self
                         .weighted_threshold_access_structure
                         .is_authorized_subset(
                             &self
@@ -655,7 +655,7 @@ impl DWalletMPCSession {
                                 .collect::<HashSet<PartyID>>(),
                         )
                         .is_ok()
-                        && self.received_more_messages_since_last_retry
+                        && self.received_more_messages_since_last_retry)
                 {
                     ReadyToAdvanceCheckResult {
                         is_ready: true,

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -545,6 +545,7 @@ impl DWalletMPCSession {
     /// Every new message received for a session is stored.
     /// When a threshold of messages is reached, the session advances.
     pub(crate) fn store_message(&mut self, message: &DWalletMPCMessage) -> DwalletMPCResult<()> {
+        self.received_more_messages_since_last_retry = true;
         // This happens because we clear the session when it is finished, and change the status,
         // so we might receive a message with delay, and it's irrelevant.
         if self.status != MPCSessionStatus::Active {
@@ -657,6 +658,7 @@ impl DWalletMPCSession {
                                 .collect::<HashSet<PartyID>>(),
                         )
                         .is_ok()
+                        && self.received_more_messages_since_last_retry
                 {
                     ReadyToAdvanceCheckResult {
                         is_ready: true,

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -88,7 +88,7 @@ pub(super) struct DWalletMPCSession {
     weighted_threshold_access_structure: WeightedThresholdAccessStructure,
     pub(crate) mpc_event_data: Option<MPCEventData>,
     pub(crate) received_more_messages_since_last_retry: bool,
-    // The *total* number of attempts to advance that failed in the session. 
+    // The *total* number of attempts to advance that failed in the session.
     // Used to make `ThresholdNotReachedReport` unique.
     pub(crate) attempts_count: usize,
 }

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -315,7 +315,6 @@ impl DWalletMPCSession {
         let report_tx =
             self.new_dwallet_report_threshold_not_reached(ThresholdNotReachedReport {
                 session_id: self.session_id,
-                crypto_round_number: self.pending_quorum_for_highest_round_number,
                 attempt: self.attempts_count,
             })?;
         let epoch_store = self.epoch_store()?.clone();

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -149,11 +149,7 @@ impl DWalletMPCSession {
                 let consensus_adapter = self.consensus_adapter.clone();
                 let epoch_store = self.epoch_store()?.clone();
                 if !malicious_parties.is_empty() {
-                    self.report_malicious_actors(
-                        tokio_runtime_handle,
-                        malicious_parties,
-                        AdvanceResult::Success,
-                    )?;
+                    self.report_malicious_actors(tokio_runtime_handle, malicious_parties)?;
                 }
                 let message = self.new_dwallet_mpc_message(message)?;
                 tokio_runtime_handle.spawn(async move {
@@ -185,11 +181,7 @@ impl DWalletMPCSession {
                 let consensus_adapter = self.consensus_adapter.clone();
                 let epoch_store = self.epoch_store()?.clone();
                 if !malicious_parties.is_empty() {
-                    self.report_malicious_actors(
-                        tokio_runtime_handle,
-                        malicious_parties,
-                        AdvanceResult::Success,
-                    )?;
+                    self.report_malicious_actors(tokio_runtime_handle, malicious_parties)?;
                 }
                 let consensus_message =
                     self.new_dwallet_mpc_output_message(public_output.clone())?;
@@ -225,11 +217,12 @@ impl DWalletMPCSession {
                     party_id=?self.party_id,
                     "MPC session failed"
                 );
-                self.report_malicious_actors(
-                    tokio_runtime_handle,
-                    malicious_parties,
-                    AdvanceResult::Failure,
-                )
+                // self.report_malicious_actors(
+                //     tokio_runtime_handle,
+                //     malicious_parties,
+                //     AdvanceResult::Failure,
+                // )
+                todo!()
             }
             Err(err) => {
                 error!(?err, "failed to advance the MPC session");
@@ -300,12 +293,10 @@ impl DWalletMPCSession {
         &self,
         tokio_runtime_handle: &Handle,
         malicious_parties_ids: Vec<PartyID>,
-        advance_result: AdvanceResult,
     ) -> DwalletMPCResult<()> {
         let report = MaliciousReport::new(
             party_ids_to_authority_names(&malicious_parties_ids, &*self.epoch_store()?)?,
             self.session_id.clone(),
-            advance_result,
         );
         let report_tx = self.new_dwallet_report_failed_session_with_malicious_actors(report)?;
         let epoch_store = self.epoch_store()?.clone();

--- a/crates/ika-types/src/dwallet_mpc_error.rs
+++ b/crates/ika-types/src/dwallet_mpc_error.rs
@@ -34,8 +34,8 @@ pub enum DwalletMPCError {
     #[error("malicious parties have been detected: {0:?}")]
     MaliciousParties(Vec<PartyID>),
 
-    #[error("session failed with malicious parties: {0:?}")]
-    SessionFailedWithMaliciousParties(Vec<PartyID>),
+    #[error("two-pc MPC threshold not reached")]
+    TWOPCMPCThresholdNotReached,
 
     #[error("dWallet MPC Manager error: {0}")]
     MPCManagerError(String),

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -3,9 +3,7 @@
 
 use crate::crypto::AuthorityName;
 use crate::messages_checkpoint::{CheckpointSequenceNumber, CheckpointSignatureMessage};
-use crate::messages_dwallet_mpc::{
-    DWalletMPCMessage, DWalletMPCMessageKey, MaliciousReport, SessionInfo,
-};
+use crate::messages_dwallet_mpc::{DWalletMPCMessage, DWalletMPCMessageKey, MaliciousReport, SessionInfo, ThresholdNotReachedReport};
 use crate::supported_protocol_versions::SupportedProtocolVersionsWithHashes;
 use byteorder::{BigEndian, ReadBytesExt};
 use serde::{Deserialize, Serialize};
@@ -119,6 +117,7 @@ pub enum ConsensusTransactionKind {
     DWalletMPCOutput(AuthorityName, SessionInfo, Vec<u8>),
     /// Sending Authority and its MaliciousReport.
     DWalletMPCMaliciousReport(AuthorityName, MaliciousReport),
+    DWalletMPCThresholdNotReached(ThresholdNotReachedReport),
 }
 
 impl ConsensusTransaction {
@@ -169,6 +168,17 @@ impl ConsensusTransaction {
         Self {
             tracking_id,
             kind: ConsensusTransactionKind::DWalletMPCMaliciousReport(authority, report),
+        }
+    }
+
+    /// Create a new consensus transaction with the output of the MPC session to be sent to the parties.
+    pub fn new_dwallet_mpc_session_threshold_not_reached(report: ThresholdNotReachedReport) -> Self {
+        let mut hasher = DefaultHasher::new();
+        report.session_id.hash(&mut hasher);
+        let tracking_id = hasher.finish().to_le_bytes();
+        Self {
+            tracking_id,
+            kind: ConsensusTransactionKind::DWalletMPCThresholdNotReached(report),
         }
     }
 

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -3,7 +3,10 @@
 
 use crate::crypto::AuthorityName;
 use crate::messages_checkpoint::{CheckpointSequenceNumber, CheckpointSignatureMessage};
-use crate::messages_dwallet_mpc::{DWalletMPCMessage, DWalletMPCMessageKey, MaliciousReport, SessionInfo, ThresholdNotReachedReport};
+use crate::messages_dwallet_mpc::{
+    DWalletMPCMessage, DWalletMPCMessageKey, MaliciousReport, SessionInfo,
+    ThresholdNotReachedReport,
+};
 use crate::supported_protocol_versions::SupportedProtocolVersionsWithHashes;
 use byteorder::{BigEndian, ReadBytesExt};
 use serde::{Deserialize, Serialize};
@@ -70,11 +73,7 @@ impl Debug for ConsensusTransactionKey {
                 )
             }
             ConsensusTransactionKey::DWalletMPCThresholdNotReached(report) => {
-                write!(                
-                    f,
-                    "DWalletMPCThresholdNotReached({:?})",
-                    report
-                )
+                write!(f, "DWalletMPCThresholdNotReached({:?})", report)
             }
         }
     }
@@ -180,7 +179,9 @@ impl ConsensusTransaction {
     }
 
     /// Create a new consensus transaction with the output of the MPC session to be sent to the parties.
-    pub fn new_dwallet_mpc_session_threshold_not_reached(report: ThresholdNotReachedReport) -> Self {
+    pub fn new_dwallet_mpc_session_threshold_not_reached(
+        report: ThresholdNotReachedReport,
+    ) -> Self {
         let mut hasher = DefaultHasher::new();
         report.session_id.hash(&mut hasher);
         let tracking_id = hasher.finish().to_le_bytes();

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -118,7 +118,7 @@ pub enum ConsensusTransactionKind {
     DWalletMPCMessage(DWalletMPCMessage),
     DWalletMPCOutput(AuthorityName, SessionInfo, Vec<u8>),
     /// Sending Authority and its MaliciousReport.
-    DWalletMPCSessionFailedWithMalicious(AuthorityName, MaliciousReport),
+    DWalletMPCMaliciousReport(AuthorityName, MaliciousReport),
 }
 
 impl ConsensusTransaction {
@@ -168,7 +168,7 @@ impl ConsensusTransaction {
         let tracking_id = hasher.finish().to_le_bytes();
         Self {
             tracking_id,
-            kind: ConsensusTransactionKind::DWalletMPCSessionFailedWithMalicious(authority, report),
+            kind: ConsensusTransactionKind::DWalletMPCMaliciousReport(authority, report),
         }
     }
 
@@ -216,7 +216,7 @@ impl ConsensusTransaction {
                     *authority,
                 )
             }
-            ConsensusTransactionKind::DWalletMPCSessionFailedWithMalicious(authority, report) => {
+            ConsensusTransactionKind::DWalletMPCMaliciousReport(authority, report) => {
                 ConsensusTransactionKey::DWalletMPCSessionFailedWithMalicious(
                     *authority,
                     report.clone(),

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -39,7 +39,7 @@ pub enum ConsensusTransactionKey {
     /// address of the initiating user.
     DWalletMPCOutput(Vec<u8>, ObjectID, AuthorityName),
     DWalletMPCSessionFailedWithMalicious(AuthorityName, MaliciousReport),
-    DWalletMPCThresholdNotReached(ThresholdNotReachedReport),
+    DWalletMPCThresholdNotReached(AuthorityName, ThresholdNotReachedReport),
 }
 
 impl Debug for ConsensusTransactionKey {
@@ -72,8 +72,13 @@ impl Debug for ConsensusTransactionKey {
                     report,
                 )
             }
-            ConsensusTransactionKey::DWalletMPCThresholdNotReached(report) => {
-                write!(f, "DWalletMPCThresholdNotReached({:?})", report)
+            ConsensusTransactionKey::DWalletMPCThresholdNotReached(authority, report) => {
+                write!(
+                    f,
+                    "DWalletMPCThresholdNotReached({:?}, {:?})",
+                    authority.concise(),
+                    report,
+                )
             }
         }
     }
@@ -124,7 +129,7 @@ pub enum ConsensusTransactionKind {
     DWalletMPCOutput(AuthorityName, SessionInfo, Vec<u8>),
     /// Sending Authority and its MaliciousReport.
     DWalletMPCMaliciousReport(AuthorityName, MaliciousReport),
-    DWalletMPCThresholdNotReached(ThresholdNotReachedReport),
+    DWalletMPCThresholdNotReached(AuthorityName, ThresholdNotReachedReport),
 }
 
 impl ConsensusTransaction {
@@ -180,6 +185,7 @@ impl ConsensusTransaction {
 
     /// Create a new consensus transaction with the output of the MPC session to be sent to the parties.
     pub fn new_dwallet_mpc_session_threshold_not_reached(
+        authority: AuthorityName,
         report: ThresholdNotReachedReport,
     ) -> Self {
         let mut hasher = DefaultHasher::new();
@@ -187,7 +193,7 @@ impl ConsensusTransaction {
         let tracking_id = hasher.finish().to_le_bytes();
         Self {
             tracking_id,
-            kind: ConsensusTransactionKind::DWalletMPCThresholdNotReached(report),
+            kind: ConsensusTransactionKind::DWalletMPCThresholdNotReached(authority, report),
         }
     }
 
@@ -241,8 +247,8 @@ impl ConsensusTransaction {
                     report.clone(),
                 )
             }
-            ConsensusTransactionKind::DWalletMPCThresholdNotReached(report) => {
-                ConsensusTransactionKey::DWalletMPCThresholdNotReached(report.clone())
+            ConsensusTransactionKind::DWalletMPCThresholdNotReached(authority, report) => {
+                ConsensusTransactionKey::DWalletMPCThresholdNotReached(*authority, report.clone())
             }
         }
     }

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -36,6 +36,7 @@ pub enum ConsensusTransactionKey {
     /// address of the initiating user.
     DWalletMPCOutput(Vec<u8>, ObjectID, AuthorityName),
     DWalletMPCSessionFailedWithMalicious(AuthorityName, MaliciousReport),
+    DWalletMPCThresholdNotReached(ThresholdNotReachedReport),
 }
 
 impl Debug for ConsensusTransactionKey {
@@ -231,6 +232,9 @@ impl ConsensusTransaction {
                     *authority,
                     report.clone(),
                 )
+            }
+            ConsensusTransactionKind::DWalletMPCThresholdNotReached(report) => {
+                ConsensusTransactionKey::DWalletMPCThresholdNotReached(report.clone())
             }
         }
     }

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -183,7 +183,6 @@ impl ConsensusTransaction {
         }
     }
 
-    /// Create a new consensus transaction with the output of the MPC session to be sent to the parties.
     pub fn new_dwallet_mpc_session_threshold_not_reached(
         authority: AuthorityName,
         report: ThresholdNotReachedReport,

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -69,6 +69,9 @@ impl Debug for ConsensusTransactionKey {
                     report,
                 )
             }
+            ConsensusTransactionKey::DWalletMPCThresholdNotReached(_) => {
+                write!(f, "DWalletMPCThresholdNotReached")
+            }
         }
     }
 }

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -69,8 +69,12 @@ impl Debug for ConsensusTransactionKey {
                     report,
                 )
             }
-            ConsensusTransactionKey::DWalletMPCThresholdNotReached(_) => {
-                write!(f, "DWalletMPCThresholdNotReached")
+            ConsensusTransactionKey::DWalletMPCThresholdNotReached(report) => {
+                write!(                
+                    f,
+                    "DWalletMPCThresholdNotReached({:?})",
+                    report
+                )
             }
         }
     }

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -349,14 +349,11 @@ pub struct MaliciousReport {
     pub session_id: ObjectID,
 }
 
-/// Represents a report of malicious behavior in the dWallet MPC process.
-///
-/// This struct is used to record instances where validators identify malicious actors
-/// attempting to disrupt the protocol.
-/// It links the malicious actors to a specific MPC session.
+/// Represent a report that a session's cryptographic computation has failed with a threshold not reached error.
+/// 
+/// In this case, we wait 
 #[derive(PartialEq, Eq, Hash, Clone, Debug, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct ThresholdNotReachedReport {
-    /// The unique identifier of the MPC session in which the malicious activity occurred.
     pub session_id: ObjectID,
     pub crypto_round_number: usize,
 }

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -349,12 +349,6 @@ pub struct MaliciousReport {
     pub session_id: ObjectID,
 }
 
-#[derive(PartialEq, Eq, Hash, Clone, Debug, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct ThresholdNotReachedReport {
-    pub session_id: ObjectID,
-    pub attempt: usize,
-}
-
 impl MaliciousReport {
     /// Creates a new instance of a malicious report.
     pub fn new(malicious_actors: Vec<AuthorityName>, session_id: ObjectID) -> Self {
@@ -363,6 +357,14 @@ impl MaliciousReport {
             session_id,
         }
     }
+}
+
+/// Represents a report indicating that the threshold for a specific session has not been reached.
+#[derive(PartialEq, Eq, Hash, Clone, Debug, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ThresholdNotReachedReport {
+    pub session_id: ObjectID,
+    /// Attempt is needed to make this message unique in consensus and to make it unique for a quorum.
+    pub attempt: usize,
 }
 
 /// Represents the Rust version of the Move struct `ika_system::dwallet_2pc_mpc_ecdsa_k1::StartPresignFirstRoundEvent`.

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -349,9 +349,6 @@ pub struct MaliciousReport {
     pub session_id: ObjectID,
 }
 
-/// Represent a report that a session's cryptographic computation has failed with a threshold not reached error.
-/// 
-/// In this case, we wait 
 #[derive(PartialEq, Eq, Hash, Clone, Debug, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct ThresholdNotReachedReport {
     pub session_id: ObjectID,

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -352,7 +352,6 @@ pub struct MaliciousReport {
 #[derive(PartialEq, Eq, Hash, Clone, Debug, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct ThresholdNotReachedReport {
     pub session_id: ObjectID,
-    pub crypto_round_number: usize,
     pub attempt: usize,
 }
 

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -359,7 +359,6 @@ pub struct ThresholdNotReachedReport {
     /// The unique identifier of the MPC session in which the malicious activity occurred.
     pub session_id: ObjectID,
     pub crypto_round_number: usize,
-    pub authority: AuthorityName,
 }
 
 impl MaliciousReport {

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -353,6 +353,7 @@ pub struct MaliciousReport {
 pub struct ThresholdNotReachedReport {
     pub session_id: ObjectID,
     pub crypto_round_number: usize,
+    pub attempt: usize,
 }
 
 impl MaliciousReport {

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -345,22 +345,16 @@ pub enum AdvanceResult {
 pub struct MaliciousReport {
     /// A list of authority names that have been identified as malicious actors.
     pub malicious_actors: Vec<AuthorityName>,
-    pub advance_result: AdvanceResult,
     /// The unique identifier of the MPC session in which the malicious activity occurred.
     pub session_id: ObjectID,
 }
 
 impl MaliciousReport {
     /// Creates a new instance of a malicious report.
-    pub fn new(
-        malicious_actors: Vec<AuthorityName>,
-        session_id: ObjectID,
-        advance_result: AdvanceResult,
-    ) -> Self {
+    pub fn new(malicious_actors: Vec<AuthorityName>, session_id: ObjectID) -> Self {
         Self {
             malicious_actors,
             session_id,
-            advance_result,
         }
     }
 }

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -349,6 +349,19 @@ pub struct MaliciousReport {
     pub session_id: ObjectID,
 }
 
+/// Represents a report of malicious behavior in the dWallet MPC process.
+///
+/// This struct is used to record instances where validators identify malicious actors
+/// attempting to disrupt the protocol.
+/// It links the malicious actors to a specific MPC session.
+#[derive(PartialEq, Eq, Hash, Clone, Debug, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ThresholdNotReachedReport {
+    /// The unique identifier of the MPC session in which the malicious activity occurred.
+    pub session_id: ObjectID,
+    pub crypto_round_number: usize,
+    pub authority: AuthorityName,
+}
+
 impl MaliciousReport {
     /// Creates a new instance of a malicious report.
     pub fn new(malicious_actors: Vec<AuthorityName>, session_id: ObjectID) -> Self {

--- a/sdk/dwallet-mpc-wasm/Cargo.lock
+++ b/sdk/dwallet-mpc-wasm/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
 [[package]]
 name = "class_groups"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "commitment",
  "crypto-bigint",
@@ -216,7 +216,7 @@ dependencies = [
 [[package]]
 name = "commitment"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "crypto-bigint",
  "group 0.1.0",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "enhanced_maurer"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "commitment",
  "crypto-bigint",
@@ -624,7 +624,7 @@ dependencies = [
 [[package]]
 name = "group"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "crypto-bigint",
  "curve25519-dalek-ng",
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "homomorphic_encryption"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "crypto-bigint",
  "getrandom",
@@ -877,7 +877,7 @@ checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 [[package]]
 name = "maurer"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "commitment",
  "crypto-bigint",
@@ -947,13 +947,14 @@ dependencies = [
 [[package]]
 name = "mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "commitment",
  "crypto-bigint",
  "gcd",
  "getrandom",
  "group 0.1.0",
+ "itertools",
  "rand",
  "rayon",
  "serde",
@@ -1147,7 +1148,7 @@ dependencies = [
 [[package]]
 name = "proof"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "bulletproofs",
  "commitment",
@@ -1637,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "tiresias"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "crypto-bigint",
  "crypto-primes",
@@ -1662,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "twopc_mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=3ad27518#3ad275181dc2de14203df3b892512da4220f802e"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
 dependencies = [
  "class_groups",
  "commitment",

--- a/sdk/dwallet-mpc-wasm/Cargo.lock
+++ b/sdk/dwallet-mpc-wasm/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
 [[package]]
 name = "class_groups"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "commitment",
  "crypto-bigint",
@@ -216,7 +216,7 @@ dependencies = [
 [[package]]
 name = "commitment"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "crypto-bigint",
  "group 0.1.0",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "enhanced_maurer"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "commitment",
  "crypto-bigint",
@@ -624,7 +624,7 @@ dependencies = [
 [[package]]
 name = "group"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "crypto-bigint",
  "curve25519-dalek-ng",
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "homomorphic_encryption"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "crypto-bigint",
  "getrandom",
@@ -877,7 +877,7 @@ checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 [[package]]
 name = "maurer"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "commitment",
  "crypto-bigint",
@@ -947,7 +947,7 @@ dependencies = [
 [[package]]
 name = "mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "commitment",
  "crypto-bigint",
@@ -1148,7 +1148,7 @@ dependencies = [
 [[package]]
 name = "proof"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "bulletproofs",
  "commitment",
@@ -1638,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "tiresias"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "crypto-bigint",
  "crypto-primes",
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "twopc_mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=508d952#508d952cc2f6adfdbeabc854960909a787087042"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=4f4c8d3#4f4c8d31dd896ab833f133d1ab524f349c5a8dfb"
 dependencies = [
  "class_groups",
  "commitment",


### PR DESCRIPTION
Until now, our malicious actor handling mechanism worked properly only when rolling back a single round after a session failure due to malicious behavior. While this sufficed in most cases, the network DKG and Reshare flows require rolling back multiple rounds. This PR correctly implements those flows by leveraging Scaly's new code. When a `ThresholdNotReached` error is received, the system now waits for additional messages (including those from previous rounds) and retries.

[This draft PR](https://github.com/dwallet-labs/dwallet-network/pull/1013) includes a passing e2e test that shows the new malicious handling mechanism actually works.