### PR TITLE
fix: Assure the Sui notifier executes one transaction at a time

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -887,7 +887,14 @@ impl DWalletMPCSession {
     /// - If delay is satisfied: resets the consensus round counter and returns `is_ready: true`
     /// - If no delay is required for the current protocol/round: returns `is_ready: true`
     fn wait_consensus_rounds_delay(&mut self) -> DwalletMPCResult<ReadyToAdvanceCheckResult> {
-        // Safe to unwrap as this function is only called after the MPC event is received.
+        if self.mpc_event_data.clone().is_none() {
+            return Ok(
+                ReadyToAdvanceCheckResult {
+                    is_ready: false,
+                    malicious_parties: vec![],
+                },
+            )
+        }
         match &self.mpc_event_data.clone().unwrap().init_protocol_data {
             MPCProtocolInitData::Sign(_) => {
                 let delay = self

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -28,10 +28,7 @@ use crate::dwallet_mpc::{message_digest, party_ids_to_authority_names, MPCSessio
 use crate::stake_aggregator::StakeAggregator;
 use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use ika_types::messages_consensus::ConsensusTransaction;
-use ika_types::messages_dwallet_mpc::{
-    DWalletMPCMessage, EncryptedShareVerificationRequestEvent, MPCProtocolInitData,
-    MaliciousReport, SessionInfo, SessionType, ThresholdNotReachedReport,
-};
+use ika_types::messages_dwallet_mpc::{DWalletMPCMessage, EncryptedShareVerificationRequestEvent, MPCProtocolInitData, MaliciousReport, SessionInfo, SessionType, ThresholdNotReachedReport, DECRYPTION_KEY_RESHARE_STR_KEY, NETWORK_DKG_STR_KEY, SIGN_STR_KEY};
 use sui_types::base_types::{EpochId, ObjectID};
 
 pub(crate) type AsyncProtocol = twopc_mpc::secp256k1::class_groups::AsyncProtocol;
@@ -894,21 +891,21 @@ impl DWalletMPCSession {
             });
         }
         match &self.agreed_mpc_protocol.clone().unwrap() {
-            MPCProtocolInitData::Sign(_) => {
+            protocol if protocol == SIGN_STR_KEY => {
                 let delay = self
                     .epoch_store()?
                     .protocol_config()
                     .sign_second_round_delay() as usize;
                 self.check_round_delay(Self::SIGN_DELAY_ROUND, delay)
             }
-            MPCProtocolInitData::NetworkDkg(_, _) => {
+            protocol if protocol == NETWORK_DKG_STR_KEY => {
                 let delay = self
                     .epoch_store()?
                     .protocol_config()
                     .network_dkg_third_round_delay() as usize;
                 self.check_round_delay(Self::NETWORK_DKG_DELAY_ROUND, delay)
             }
-            MPCProtocolInitData::DecryptionKeyReshare(_) => {
+            protocol if protocol == DECRYPTION_KEY_RESHARE_STR_KEY => {
                 let delay =
                     self.epoch_store()?
                         .protocol_config()

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -887,13 +887,13 @@ impl DWalletMPCSession {
     /// - If delay is satisfied: resets the consensus round counter and returns `is_ready: true`
     /// - If no delay is required for the current protocol/round: returns `is_ready: true`
     fn wait_consensus_rounds_delay(&mut self) -> DwalletMPCResult<ReadyToAdvanceCheckResult> {
-        if self.mpc_event_data.clone().is_none() {
+        if self.agreed_mpc_protocol.is_none() {
             return Ok(ReadyToAdvanceCheckResult {
                 is_ready: false,
                 malicious_parties: vec![],
             });
         }
-        match &self.mpc_event_data.clone().unwrap().init_protocol_data {
+        match &self.agreed_mpc_protocol.clone().unwrap() {
             MPCProtocolInitData::Sign(_) => {
                 let delay = self
                     .epoch_store()?

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -28,7 +28,11 @@ use crate::dwallet_mpc::{message_digest, party_ids_to_authority_names, MPCSessio
 use crate::stake_aggregator::StakeAggregator;
 use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use ika_types::messages_consensus::ConsensusTransaction;
-use ika_types::messages_dwallet_mpc::{DWalletMPCMessage, EncryptedShareVerificationRequestEvent, MPCProtocolInitData, MaliciousReport, SessionInfo, SessionType, ThresholdNotReachedReport, DECRYPTION_KEY_RESHARE_STR_KEY, NETWORK_DKG_STR_KEY, SIGN_STR_KEY};
+use ika_types::messages_dwallet_mpc::{
+    DWalletMPCMessage, EncryptedShareVerificationRequestEvent, MPCProtocolInitData,
+    MaliciousReport, SessionInfo, SessionType, ThresholdNotReachedReport,
+    DECRYPTION_KEY_RESHARE_STR_KEY, NETWORK_DKG_STR_KEY, SIGN_STR_KEY,
+};
 use sui_types::base_types::{EpochId, ObjectID};
 
 pub(crate) type AsyncProtocol = twopc_mpc::secp256k1::class_groups::AsyncProtocol;

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -888,12 +888,10 @@ impl DWalletMPCSession {
     /// - If no delay is required for the current protocol/round: returns `is_ready: true`
     fn wait_consensus_rounds_delay(&mut self) -> DwalletMPCResult<ReadyToAdvanceCheckResult> {
         if self.mpc_event_data.clone().is_none() {
-            return Ok(
-                ReadyToAdvanceCheckResult {
-                    is_ready: false,
-                    malicious_parties: vec![],
-                },
-            )
+            return Ok(ReadyToAdvanceCheckResult {
+                is_ready: false,
+                malicious_parties: vec![],
+            });
         }
         match &self.mpc_event_data.clone().unwrap().init_protocol_data {
             MPCProtocolInitData::Sign(_) => {

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -896,7 +896,7 @@ where
         sui_notifier: &SuiNotifier,
         sui_client: &Arc<SuiClient<C>>,
         _metrics: &Arc<SuiConnectorMetrics>,
-        notifier_coin_lock: tokio::sync::Mutex<Option<TransactionDigest>>,
+        notifier_coin_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
     ) -> IkaResult<()> {
         let mut ptb = ProgrammableTransactionBuilder::new();
 

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -519,7 +519,7 @@ where
         ika_system_package_id: ObjectID,
         sui_notifier: &SuiNotifier,
         dwallet_coordinator_id: ObjectID,
-        notifier_coin_lock: tokio::sync::Mutex<Option<TransactionDigest>>,
+        notifier_coin_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
     ) -> anyhow::Result<()> {
         let gas_coins = sui_client.get_gas_objects(sui_notifier.sui_address).await;
         let gas_coin = gas_coins
@@ -688,7 +688,7 @@ where
     }
 
     async fn submit_tx_to_sui(
-        notifier_coin_lock: tokio::sync::Mutex<Option<TransactionDigest>>,
+        notifier_coin_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
         transaction: Transaction,
         sui_client: &Arc<SuiClient<C>>,
     ) -> DwalletMPCResult<()> {
@@ -722,7 +722,7 @@ where
         dwallet_2pc_mpc_coordinator_id: ObjectID,
         sui_notifier: &SuiNotifier,
         sui_client: &Arc<SuiClient<C>>,
-        notifier_coin_lock: tokio::sync::Mutex<Option<TransactionDigest>>,
+        notifier_coin_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
     ) -> IkaResult<()> {
         info!("Running `process_mid_epoch()`");
         let gas_coins = sui_client.get_gas_objects(sui_notifier.sui_address).await;
@@ -778,7 +778,7 @@ where
         dwallet_2pc_mpc_coordinator_id: ObjectID,
         sui_notifier: &SuiNotifier,
         sui_client: &Arc<SuiClient<C>>,
-        notifier_coin_lock: tokio::sync::Mutex<Option<TransactionDigest>>,
+        notifier_coin_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
     ) -> IkaResult<()> {
         info!("Process `lock_last_active_session_sequence_number()`");
         let gas_coins = sui_client.get_gas_objects(sui_notifier.sui_address).await;
@@ -835,7 +835,7 @@ where
         dwallet_2pc_mpc_coordinator_id: ObjectID,
         sui_notifier: &SuiNotifier,
         sui_client: &Arc<SuiClient<C>>,
-        notifier_coin_lock: tokio::sync::Mutex<Option<TransactionDigest>>,
+        notifier_coin_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
     ) -> IkaResult<()> {
         info!("Running `process_request_advance_epoch()`");
         let gas_coins = sui_client.get_gas_objects(sui_notifier.sui_address).await;
@@ -998,7 +998,7 @@ where
         sui_notifier: &SuiNotifier,
         sui_client: &Arc<SuiClient<C>>,
         _metrics: &Arc<SuiConnectorMetrics>,
-        notifier_coin_lock: tokio::sync::Mutex<Option<TransactionDigest>>,
+        notifier_coin_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
     ) -> IkaResult<()> {
         let mut ptb = ProgrammableTransactionBuilder::new();
 

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -84,7 +84,7 @@ where
             sui_notifier,
             sui_client,
             metrics,
-            notifier_coin_lock: tokio::sync::Mutex::new(None),
+            notifier_coin_lock: Arc::new(tokio::sync::Mutex::new(None)),
         }
     }
 

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -130,7 +130,7 @@ where
                 sui_notifier,
                 &self.sui_client,
             )
-                .await
+            .await
             {
                 error!("`process_mid_epoch()` failed: {:?}", e);
             } else {
@@ -158,7 +158,7 @@ where
                 sui_notifier,
                 dwallet_2pc_mpc_coordinator_id,
             )
-                .await
+            .await
             {
                 Ok(..) => {
                     info!("Successfully calculated protocols pricing");
@@ -185,7 +185,7 @@ where
                 sui_notifier,
                 &self.sui_client,
             )
-                .await
+            .await
             {
                 error!(
                     "failed to lock last active session sequence number: {:?}",
@@ -218,7 +218,7 @@ where
                 sui_notifier,
                 &self.sui_client,
             )
-                .await
+            .await
             {
                 error!("failed to process request advance epoch: {:?}", e);
             } else {
@@ -318,7 +318,7 @@ where
                     &ika_system_state_inner,
                     &mut epoch_switch_state,
                 )
-                    .await;
+                .await;
                 if Some(next_dwallet_checkpoint_sequence_number) > last_submitted_dwallet_checkpoint
                 {
                     match self
@@ -351,7 +351,7 @@ where
                                     let message = bcs::to_bytes::<DWalletCheckpointMessage>(
                                         &dwallet_checkpoint_message.into_message(),
                                     )
-                                        .expect("Serializing checkpoint message cannot fail");
+                                    .expect("Serializing checkpoint message cannot fail");
 
                                     info!(
                                         signers_len=?signers_len,
@@ -369,7 +369,7 @@ where
                                         &self.sui_client,
                                         &self.metrics,
                                     )
-                                        .await;
+                                    .await;
                                     match task {
                                         Ok(_) => {
                                             self.metrics
@@ -446,7 +446,7 @@ where
                             let message = bcs::to_bytes::<SystemCheckpoint>(
                                 &system_checkpoint.into_message(),
                             )
-                                .expect("Serializing system_checkpoint message cannot fail");
+                            .expect("Serializing system_checkpoint message cannot fail");
 
                             info!("Signers_bitmap: {:?}", signers_bitmap);
 
@@ -459,7 +459,7 @@ where
                                 &self.sui_client,
                                 &self.metrics,
                             )
-                                .await;
+                            .await;
                             match task {
                                 Ok(_) => {
                                     last_submitted_system_checkpoint =
@@ -673,7 +673,7 @@ where
             vec![*gas_coin],
             &sui_notifier.sui_key,
         )
-            .await;
+        .await;
 
         let result = sui_client
             .execute_transaction_block_with_effects(transaction)
@@ -706,7 +706,7 @@ where
                     .execute_transaction_block_with_effects(transaction)
                     .await?;
                 *digest = Some(result.digest);
-                return Ok(())
+                return Ok(());
             } else {
                 match sui_client.get_events_by_tx_digest(digest.unwrap()).await {
                     Err(_) => continue,
@@ -715,7 +715,7 @@ where
                             .execute_transaction_block_with_effects(transaction)
                             .await?;
                         *digest = Some(result.digest);
-                        return Ok(())
+                        return Ok(());
                     }
                 }
             }
@@ -757,11 +757,11 @@ where
             vec![],
             args,
         )
-            .map_err(|e| {
-                IkaError::SuiConnectorInternalError(format!(
-                    "failed on ProgrammableTransactionBuilder::move_call: {e}"
-                ))
-            })?;
+        .map_err(|e| {
+            IkaError::SuiConnectorInternalError(format!(
+                "failed on ProgrammableTransactionBuilder::move_call: {e}"
+            ))
+        })?;
 
         let transaction = super::build_sui_transaction(
             sui_notifier.sui_address,
@@ -770,7 +770,7 @@ where
             vec![*gas_coin],
             &sui_notifier.sui_key,
         )
-            .await;
+        .await;
 
         sui_client
             .execute_transaction_block_with_effects(transaction)
@@ -815,11 +815,11 @@ where
             vec![],
             args,
         )
-            .map_err(|e| {
-                IkaError::SuiConnectorInternalError(format!(
-                    "failed on ProgrammableTransactionBuilder::move_call: {e}"
-                ))
-            })?;
+        .map_err(|e| {
+            IkaError::SuiConnectorInternalError(format!(
+                "failed on ProgrammableTransactionBuilder::move_call: {e}"
+            ))
+        })?;
 
         let transaction = super::build_sui_transaction(
             sui_notifier.sui_address,
@@ -828,7 +828,7 @@ where
             vec![*gas_coin],
             &sui_notifier.sui_key,
         )
-            .await;
+        .await;
 
         sui_client
             .execute_transaction_block_with_effects(transaction)
@@ -873,11 +873,11 @@ where
             vec![],
             args,
         )
-            .map_err(|e| {
-                IkaError::SuiConnectorInternalError(format!(
-                    "failed on ProgrammableTransactionBuilder::move_call {e}"
-                ))
-            })?;
+        .map_err(|e| {
+            IkaError::SuiConnectorInternalError(format!(
+                "failed on ProgrammableTransactionBuilder::move_call {e}"
+            ))
+        })?;
 
         let transaction = super::build_sui_transaction(
             sui_notifier.sui_address,
@@ -886,7 +886,7 @@ where
             vec![*gas_coin],
             &sui_notifier.sui_key,
         )
-            .await;
+        .await;
 
         sui_client
             .execute_transaction_block_with_effects(transaction)
@@ -990,7 +990,7 @@ where
             vec![*gas_coin],
             &sui_notifier.sui_key,
         )
-            .await;
+        .await;
 
         sui_client
             .execute_transaction_block_with_effects(transaction)
@@ -1069,11 +1069,11 @@ where
             vec![],
             args,
         )
-            .map_err(|e| {
-                IkaError::SuiConnectorInternalError(format!(
-                    "Can't ProgrammableTransactionBuilder::move_call: {e}"
-                ))
-            })?;
+        .map_err(|e| {
+            IkaError::SuiConnectorInternalError(format!(
+                "Can't ProgrammableTransactionBuilder::move_call: {e}"
+            ))
+        })?;
 
         let transaction = super::build_sui_transaction(
             sui_notifier.sui_address,
@@ -1082,7 +1082,7 @@ where
             vec![*gas_coin],
             &sui_notifier.sui_key,
         )
-            .await;
+        .await;
 
         sui_client
             .execute_transaction_block_with_effects(transaction)

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -712,7 +712,7 @@ where
                     Err(_) => continue,
                     Ok(_events) => {
                         let result = sui_client
-                            .execute_transaction_block_with_effects(transaction)
+                            .execute_transaction_block_with_effects(transaction.clone())
                             .await?;
                         *digest = Some(result.digest);
                     }

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -714,7 +714,7 @@ where
                             "Last submitted transaction has not been processed yet, retrying..."
                         );
                         continue;
-                    },
+                    }
                     Ok(_events) => {
                         info!(
                             transaction_digest = ?digest,

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -55,7 +55,7 @@ pub struct SuiExecutor<C> {
     sui_notifier: Option<SuiNotifier>,
     sui_client: Arc<SuiClient<C>>,
     metrics: Arc<SuiConnectorMetrics>,
-    notifier_coin_lock: tokio::sync::Mutex<Option<TransactionDigest>>,
+    notifier_coin_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
 }
 
 struct EpochSwitchState {
@@ -129,6 +129,7 @@ where
                 dwallet_2pc_mpc_coordinator_id,
                 sui_notifier,
                 &self.sui_client,
+                self.notifier_coin_lock.clone()
             )
             .await
             {
@@ -157,6 +158,7 @@ where
                 self.ika_system_package_id,
                 sui_notifier,
                 dwallet_2pc_mpc_coordinator_id,
+                self.notifier_coin_lock.clone()
             )
             .await
             {
@@ -184,6 +186,7 @@ where
                 dwallet_2pc_mpc_coordinator_id,
                 sui_notifier,
                 &self.sui_client,
+                self.notifier_coin_lock.clone()
             )
             .await
             {
@@ -217,6 +220,7 @@ where
                 dwallet_2pc_mpc_coordinator_id,
                 sui_notifier,
                 &self.sui_client,
+                self.notifier_coin_lock.clone()
             )
             .await
             {
@@ -368,6 +372,7 @@ where
                                         sui_notifier,
                                         &self.sui_client,
                                         &self.metrics,
+                                        self.notifier_coin_lock.clone()
                                     )
                                     .await;
                                     match task {
@@ -458,6 +463,7 @@ where
                                 sui_notifier,
                                 &self.sui_client,
                                 &self.metrics,
+                                self.notifier_coin_lock.clone()
                             )
                             .await;
                             match task {

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -712,9 +712,10 @@ where
                     Err(_) => continue,
                     Ok(_events) => {
                         let result = sui_client
-                            .execute_transaction_block_with_effects(transaction.clone())
+                            .execute_transaction_block_with_effects(transaction)
                             .await?;
                         *digest = Some(result.digest);
+                        return Ok(())
                     }
                 }
             }

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -513,6 +513,7 @@ where
         ika_system_package_id: ObjectID,
         sui_notifier: &SuiNotifier,
         dwallet_coordinator_id: ObjectID,
+        notifier_coin_lock: tokio::sync::Mutex<Option<TransactionDigest>>,
     ) -> anyhow::Result<()> {
         let gas_coins = sui_client.get_gas_objects(sui_notifier.sui_address).await;
         let gas_coin = gas_coins
@@ -675,19 +676,7 @@ where
         )
         .await;
 
-        let result = sui_client
-            .execute_transaction_block_with_effects(transaction)
-            .await?;
-        if !result.errors.is_empty() {
-            for error in result.errors.clone() {
-                error!(?error, "error executing transaction block");
-            }
-            return Err(anyhow::anyhow!(
-                "calculate_protocols_pricing failed with errors: {:?}",
-                result.errors
-            ));
-        }
-        info!(?result.digest, "Successfully executed transaction block for protocol pricing calculation");
+        Self::submit_tx_to_sui(notifier_coin_lock, transaction, sui_client).await?;
 
         Ok(())
     }
@@ -727,6 +716,7 @@ where
         dwallet_2pc_mpc_coordinator_id: ObjectID,
         sui_notifier: &SuiNotifier,
         sui_client: &Arc<SuiClient<C>>,
+        notifier_coin_lock: tokio::sync::Mutex<Option<TransactionDigest>>,
     ) -> IkaResult<()> {
         info!("Running `process_mid_epoch()`");
         let gas_coins = sui_client.get_gas_objects(sui_notifier.sui_address).await;
@@ -772,9 +762,7 @@ where
         )
         .await;
 
-        sui_client
-            .execute_transaction_block_with_effects(transaction)
-            .await?;
+        Self::submit_tx_to_sui(notifier_coin_lock, transaction, sui_client).await?;
 
         Ok(())
     }
@@ -784,6 +772,7 @@ where
         dwallet_2pc_mpc_coordinator_id: ObjectID,
         sui_notifier: &SuiNotifier,
         sui_client: &Arc<SuiClient<C>>,
+        notifier_coin_lock: tokio::sync::Mutex<Option<TransactionDigest>>,
     ) -> IkaResult<()> {
         info!("Process `lock_last_active_session_sequence_number()`");
         let gas_coins = sui_client.get_gas_objects(sui_notifier.sui_address).await;
@@ -830,9 +819,7 @@ where
         )
         .await;
 
-        sui_client
-            .execute_transaction_block_with_effects(transaction)
-            .await?;
+        Self::submit_tx_to_sui(notifier_coin_lock, transaction, sui_client).await?;
 
         Ok(())
     }
@@ -842,6 +829,7 @@ where
         dwallet_2pc_mpc_coordinator_id: ObjectID,
         sui_notifier: &SuiNotifier,
         sui_client: &Arc<SuiClient<C>>,
+        notifier_coin_lock: tokio::sync::Mutex<Option<TransactionDigest>>,
     ) -> IkaResult<()> {
         info!("Running `process_request_advance_epoch()`");
         let gas_coins = sui_client.get_gas_objects(sui_notifier.sui_address).await;
@@ -888,9 +876,7 @@ where
         )
         .await;
 
-        sui_client
-            .execute_transaction_block_with_effects(transaction)
-            .await?;
+        Self::submit_tx_to_sui(notifier_coin_lock, transaction, sui_client).await?;
 
         Ok(())
     }
@@ -904,6 +890,7 @@ where
         sui_notifier: &SuiNotifier,
         sui_client: &Arc<SuiClient<C>>,
         _metrics: &Arc<SuiConnectorMetrics>,
+        notifier_coin_lock: tokio::sync::Mutex<Option<TransactionDigest>>,
     ) -> IkaResult<()> {
         let mut ptb = ProgrammableTransactionBuilder::new();
 
@@ -992,9 +979,7 @@ where
         )
         .await;
 
-        sui_client
-            .execute_transaction_block_with_effects(transaction)
-            .await?;
+        Self::submit_tx_to_sui(notifier_coin_lock, transaction, sui_client).await?;
 
         Ok(())
     }
@@ -1007,6 +992,7 @@ where
         sui_notifier: &SuiNotifier,
         sui_client: &Arc<SuiClient<C>>,
         _metrics: &Arc<SuiConnectorMetrics>,
+        notifier_coin_lock: tokio::sync::Mutex<Option<TransactionDigest>>,
     ) -> IkaResult<()> {
         let mut ptb = ProgrammableTransactionBuilder::new();
 
@@ -1084,9 +1070,7 @@ where
         )
         .await;
 
-        sui_client
-            .execute_transaction_block_with_effects(transaction)
-            .await?;
+        Self::submit_tx_to_sui(notifier_coin_lock, transaction, sui_client).await?;
 
         Ok(())
     }

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -84,7 +84,7 @@ where
             sui_notifier,
             sui_client,
             metrics,
-            notifier_coin_lock: Arc::new(tokio::sync::Mutex::new(None)),
+            notifier_coin_lock: Arc::new(tokio::sync::Mutex::new(Some(TransactionDigest::random()))),
         }
     }
 

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -129,7 +129,7 @@ where
                 dwallet_2pc_mpc_coordinator_id,
                 sui_notifier,
                 &self.sui_client,
-                self.notifier_coin_lock.clone()
+                self.notifier_coin_lock.clone(),
             )
             .await
             {
@@ -158,7 +158,7 @@ where
                 self.ika_system_package_id,
                 sui_notifier,
                 dwallet_2pc_mpc_coordinator_id,
-                self.notifier_coin_lock.clone()
+                self.notifier_coin_lock.clone(),
             )
             .await
             {
@@ -186,7 +186,7 @@ where
                 dwallet_2pc_mpc_coordinator_id,
                 sui_notifier,
                 &self.sui_client,
-                self.notifier_coin_lock.clone()
+                self.notifier_coin_lock.clone(),
             )
             .await
             {
@@ -220,7 +220,7 @@ where
                 dwallet_2pc_mpc_coordinator_id,
                 sui_notifier,
                 &self.sui_client,
-                self.notifier_coin_lock.clone()
+                self.notifier_coin_lock.clone(),
             )
             .await
             {
@@ -372,7 +372,7 @@ where
                                         sui_notifier,
                                         &self.sui_client,
                                         &self.metrics,
-                                        self.notifier_coin_lock.clone()
+                                        self.notifier_coin_lock.clone(),
                                     )
                                     .await;
                                     match task {
@@ -463,7 +463,7 @@ where
                                 sui_notifier,
                                 &self.sui_client,
                                 &self.metrics,
-                                self.notifier_coin_lock.clone()
+                                self.notifier_coin_lock.clone(),
                             )
                             .await;
                             match task {

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -84,7 +84,7 @@ where
             sui_notifier,
             sui_client,
             metrics,
-            notifier_coin_lock: Arc::new(tokio::sync::Mutex::new(Some(TransactionDigest::random()))),
+            notifier_coin_lock: Arc::new(tokio::sync::Mutex::new(None)),
         }
     }
 

--- a/crates/ika-core/src/system_checkpoints/mod.rs
+++ b/crates/ika-core/src/system_checkpoints/mod.rs
@@ -709,8 +709,6 @@ impl SystemCheckpointBuilder {
                 "SystemCheckpointBuilder::create_system_checkpoints: {} messages to be included in system_checkpoint",
                 all_messages.len()
             );
-
-            println!("{:?}", all_messages);
         }
         let chunks = self.split_system_checkpoint_chunks(all_messages)?;
         let chunks_count = chunks.len();

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -139,8 +139,7 @@ where
         &self,
         tx_digest: TransactionDigest,
     ) -> anyhow::Result<Vec<SuiEvent>> {
-        let events = self.inner.get_events_by_tx_digest(tx_digest).await?;
-        Ok(events)
+        Ok(self.inner.get_events_by_tx_digest(tx_digest).await?)
     }
 
     /// Remaining sessions not processed during previous Epochs.

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -139,9 +139,10 @@ where
         &self,
         tx_digest: TransactionDigest,
     ) -> anyhow::Result<Vec<SuiEvent>> {
-        self.inner.get_events_by_tx_digest(tx_digest).await
+        let events = self.inner.get_events_by_tx_digest(tx_digest).await?;
+        Ok(events)
     }
-    
+
     /// Remaining sessions not processed during previous Epochs.
     pub async fn get_dwallet_mpc_missed_events(
         &self,

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -135,6 +135,13 @@ impl<P> SuiClient<P>
 where
     P: SuiClientInner,
 {
+    pub async fn get_events_by_tx_digest(
+        &self,
+        tx_digest: TransactionDigest,
+    ) -> anyhow::Result<Vec<SuiEvent>> {
+        self.inner.get_events_by_tx_digest(tx_digest).await
+    }
+    
     /// Remaining sessions not processed during previous Epochs.
     pub async fn get_dwallet_mpc_missed_events(
         &self,

--- a/crates/ika-swarm-config/src/sui_client.rs
+++ b/crates/ika-swarm-config/src/sui_client.rs
@@ -164,9 +164,6 @@ pub async fn init_ika_on_sui(
             .await?;
     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
 
-    merge_coins(publisher_address, &mut context).await?;
-    println!("Merge coins done, address {:?}", publisher_address);
-
     println!("Package `ika` published: ika_package_id: {ika_package_id} treasury_cap_id: {treasury_cap_id}");
 
     let (ika_system_package_id, init_cap_id, ika_system_package_upgrade_cap_id) =
@@ -843,37 +840,6 @@ async fn request_add_validator(
     let tx_kind = TransactionKind::ProgrammableTransaction(ptb.finish());
 
     let _ = execute_sui_transaction(validator_address, tx_kind, context, vec![]).await?;
-
-    Ok(())
-}
-
-async fn merge_coins(
-    publisher_address: SuiAddress,
-    context: &mut WalletContext,
-) -> Result<(), anyhow::Error> {
-    let coins = context
-        .get_all_gas_objects_owned_by_address(publisher_address)
-        .await?;
-    let mut ptb = ProgrammableTransactionBuilder::new();
-    let gas_coin = coins.first().unwrap();
-    let coins = coins
-        .iter()
-        .skip(1)
-        .map(|c| {
-            ptb.input(CallArg::Object(ObjectArg::ImmOrOwnedObject(*c)))
-                // Safe to unwrap as this function is only being called at the swarm config.
-                .unwrap()
-        })
-        .collect::<Vec<_>>();
-
-    ptb.command(sui_types::transaction::Command::MergeCoins(
-        // Safe to unwrap as this function is only being called at the swarm config.
-        Argument::GasCoin,
-        // Keep the gas object out
-        coins.to_vec(),
-    ));
-    let tx_kind = TransactionKind::ProgrammableTransaction(ptb.finish());
-    let _ = execute_sui_transaction(publisher_address, tx_kind, context, vec![gas_coin.0]).await?;
 
     Ok(())
 }

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -29,6 +29,10 @@ pub const SIGN_PROTOCOL_FLAG: u32 = 6;
 pub const FUTURE_SIGN_PROTOCOL_FLAG: u32 = 7;
 pub const SIGN_WITH_PARTIAL_USER_SIGNATURE_PROTOCOL_FLAG: u32 = 8;
 
+pub const DECRYPTION_KEY_RESHARE_STR_KEY: &'static str = "DecryptionKeyReshare";
+pub const NETWORK_DKG_STR_KEY: &'static str = "NetworkDkg";
+pub const SIGN_STR_KEY: &'static str = "Sign";
+
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum MPCProtocolInitData {
     /// Make the dWallet user secret key shares public, so the network can control it.
@@ -70,10 +74,6 @@ pub enum MPCProtocolInitData {
     PartialSignatureVerification(DWalletMPCSuiEvent<FutureSignRequestEvent>),
     DecryptionKeyReshare(DWalletMPCSuiEvent<DWalletEncryptionKeyReconfigurationRequestEvent>),
 }
-
-pub const DECRYPTION_KEY_RESHARE_STR_KEY: &'static str = "DecryptionKeyReshare";
-pub const NETWORK_DKG_STR_KEY: &'static str = "NetworkDkg";
-pub const SIGN_STR_KEY: &'static str = "Sign";
 
 impl Display for MPCProtocolInitData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -71,14 +71,18 @@ pub enum MPCProtocolInitData {
     DecryptionKeyReshare(DWalletMPCSuiEvent<DWalletEncryptionKeyReconfigurationRequestEvent>),
 }
 
+pub const DECRYPTION_KEY_RESHARE_STR_KEY: &'static str = "DecryptionKeyReshare";
+pub const NETWORK_DKG_STR_KEY: &'static str = "NetworkDkg";
+pub const SIGN_STR_KEY: &'static str = "Sign";
+
 impl Display for MPCProtocolInitData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             MPCProtocolInitData::DKGFirst(_) => write!(f, "dWalletDKGFirstRound"),
             MPCProtocolInitData::DKGSecond(_) => write!(f, "dWalletDKGSecondRound"),
             MPCProtocolInitData::Presign(_) => write!(f, "Presign"),
-            MPCProtocolInitData::Sign(_) => write!(f, "Sign"),
-            MPCProtocolInitData::NetworkDkg(_, _) => write!(f, "NetworkDkg"),
+            MPCProtocolInitData::Sign(_) => write!(f, "{}", SIGN_STR_KEY),
+            MPCProtocolInitData::NetworkDkg(_, _) => write!(f, "{}", NETWORK_DKG_STR_KEY),
             MPCProtocolInitData::EncryptedShareVerification(_) => {
                 write!(f, "EncryptedShareVerification")
             }
@@ -86,7 +90,7 @@ impl Display for MPCProtocolInitData {
                 write!(f, "PartialSignatureVerification")
             }
             MPCProtocolInitData::DecryptionKeyReshare(_) => {
-                write!(f, "DecryptionKeyReshare")
+                write!(f, "{}", DECRYPTION_KEY_RESHARE_STR_KEY)
             }
             MPCProtocolInitData::MakeDWalletUserSecretKeySharesPublicRequest(_) => {
                 write!(f, "MakeDWalletUserSecretKeySharesPublicRequest")

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -29,9 +29,9 @@ pub const SIGN_PROTOCOL_FLAG: u32 = 6;
 pub const FUTURE_SIGN_PROTOCOL_FLAG: u32 = 7;
 pub const SIGN_WITH_PARTIAL_USER_SIGNATURE_PROTOCOL_FLAG: u32 = 8;
 
-pub const DECRYPTION_KEY_RESHARE_STR_KEY: &'static str = "DecryptionKeyReshare";
-pub const NETWORK_DKG_STR_KEY: &'static str = "NetworkDkg";
-pub const SIGN_STR_KEY: &'static str = "Sign";
+pub const DECRYPTION_KEY_RESHARE_STR_KEY: &str = "DecryptionKeyReshare";
+pub const NETWORK_DKG_STR_KEY: &str = "NetworkDkg";
+pub const SIGN_STR_KEY: &str = "Sign";
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum MPCProtocolInitData {


### PR DESCRIPTION
This is crucial, as executing two transactions simultaneously will lock the notifier's Coin object until the end of the epoch, rendering it non-functional.

This PR also includes a bug fix in the consensus delay mechanism I discovered while working on this pr.