### PR TITLE
fix: Stop print all checkpoint messages content while debugging checkpoint fork

### DIFF
--- a/crates/ika-types/src/message.rs
+++ b/crates/ika-types/src/message.rs
@@ -217,7 +217,7 @@ impl Debug for DWalletMessageKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut writer = String::new();
         match &self {
-            DWalletMessageKind::RespondDWalletMPCNetworkDKGOutput(value) => {
+            DWalletMessageKind::RespondDWalletMPCNetworkDKGOutput(_) => {
                 writeln!(
                     writer,
                     "MessageKind : RespondDwalletMPCNetworkDKGOutput {:?}",

--- a/crates/ika-types/src/message.rs
+++ b/crates/ika-types/src/message.rs
@@ -213,6 +213,71 @@ impl Display for DWalletMessageKind {
     }
 }
 
+impl Debug for DWalletMessageKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut writer = String::new();
+        match &self {
+            DWalletMessageKind::RespondDWalletMPCNetworkDKGOutput(_) => {
+                writeln!(writer, "MessageKind : RespondDwalletMPCNetworkDKGOutput")?;
+            }
+            DWalletMessageKind::RespondDWalletDKGFirstRoundOutput(_) => {
+                writeln!(writer, "MessageKind : RespondDwalletDKGFirstRoundOutput")?;
+            }
+            DWalletMessageKind::RespondDWalletDKGSecondRoundOutput(_) => {
+                writeln!(writer, "MessageKind : RespondDwalletDKGSecondRoundOutput")?;
+            }
+            DWalletMessageKind::RespondDWalletPresign(_) => {
+                writeln!(writer, "MessageKind : RespondDwalletPresign")?;
+            }
+            DWalletMessageKind::RespondDWalletSign(_) => {
+                writeln!(writer, "MessageKind : RespondDwalletSign")?;
+            }
+            DWalletMessageKind::RespondDWalletEncryptedUserShare(_) => {
+                writeln!(writer, "MessageKind : RespondDwalletEncryptedUserShare")?;
+            }
+            DWalletMessageKind::RespondDWalletPartialSignatureVerificationOutput(_) => {
+                writeln!(
+                    writer,
+                    "MessageKind : RespondDwalletPartialSignatureVerificationOutput"
+                )?;
+            }
+            DWalletMessageKind::RespondDWalletMPCNetworkReconfigurationOutput(_) => {
+                writeln!(
+                    writer,
+                    "MessageKind : RespondDWalletMPCNetworkReconfigurationOutput"
+                )?;
+            }
+            DWalletMessageKind::RespondMakeDWalletUserSecretKeySharesPublic(_) => {
+                writeln!(
+                    writer,
+                    "MessageKind : RespondMakeDWalletUserSecretKeySharesPublic"
+                )?;
+            }
+            DWalletMessageKind::RespondDWalletImportedKeyVerificationOutput(_) => {
+                writeln!(
+                    writer,
+                    "MessageKind : RespondDWalletImportedKeyVerificationOutput"
+                )?;
+            }
+            DWalletMessageKind::SetMaxActiveSessionsBuffer(buffer_size) => {
+                writeln!(
+                    writer,
+                    "MessageKind : SetMaxActiveSessionsBuffer({})",
+                    buffer_size
+                )?;
+            }
+            DWalletMessageKind::SetGasFeeReimbursementSuiSystemCallValue(value) => {
+                writeln!(
+                    writer,
+                    "MessageKind : SetGasFeeReimbursementSuiSystemCallValue({})",
+                    value
+                )?;
+            }
+        }
+        write!(f, "{}", writer)
+    }
+}
+
 // #[enum_dispatch(MessageDataAPI)]
 // #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 // pub enum MessageKind {

--- a/crates/ika-types/src/message.rs
+++ b/crates/ika-types/src/message.rs
@@ -276,7 +276,8 @@ impl Debug for DWalletMessageKind {
             DWalletMessageKind::RespondMakeDWalletUserSecretKeySharesPublic(_) => {
                 writeln!(
                     writer,
-                    "MessageKind : RespondMakeDWalletUserSecretKeySharesPublic"
+                    "MessageKind : RespondMakeDWalletUserSecretKeySharesPublic {:?}",
+                    self.digest()
                 )?;
             }
             DWalletMessageKind::RespondDWalletImportedKeyVerificationOutput(_) => {

--- a/crates/ika-types/src/message.rs
+++ b/crates/ika-types/src/message.rs
@@ -217,34 +217,60 @@ impl Debug for DWalletMessageKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut writer = String::new();
         match &self {
-            DWalletMessageKind::RespondDWalletMPCNetworkDKGOutput(_) => {
-                writeln!(writer, "MessageKind : RespondDwalletMPCNetworkDKGOutput")?;
+            DWalletMessageKind::RespondDWalletMPCNetworkDKGOutput(value) => {
+                writeln!(
+                    writer,
+                    "MessageKind : RespondDwalletMPCNetworkDKGOutput {:?}",
+                    self.digest()
+                )?;
             }
             DWalletMessageKind::RespondDWalletDKGFirstRoundOutput(_) => {
-                writeln!(writer, "MessageKind : RespondDwalletDKGFirstRoundOutput")?;
+                writeln!(
+                    writer,
+                    "MessageKind : RespondDwalletDKGFirstRoundOutput {:?}",
+                    self.digest()
+                )?;
             }
             DWalletMessageKind::RespondDWalletDKGSecondRoundOutput(_) => {
-                writeln!(writer, "MessageKind : RespondDwalletDKGSecondRoundOutput")?;
+                writeln!(
+                    writer,
+                    "MessageKind : RespondDwalletDKGSecondRoundOutput {:?}",
+                    self.digest()
+                )?;
             }
             DWalletMessageKind::RespondDWalletPresign(_) => {
-                writeln!(writer, "MessageKind : RespondDwalletPresign")?;
+                writeln!(
+                    writer,
+                    "MessageKind : RespondDwalletPresign {:?}",
+                    self.digest()
+                )?;
             }
             DWalletMessageKind::RespondDWalletSign(_) => {
-                writeln!(writer, "MessageKind : RespondDwalletSign")?;
+                writeln!(
+                    writer,
+                    "MessageKind : RespondDwalletSign {:?}",
+                    self.digest()
+                )?;
             }
             DWalletMessageKind::RespondDWalletEncryptedUserShare(_) => {
-                writeln!(writer, "MessageKind : RespondDwalletEncryptedUserShare")?;
+                writeln!(
+                    writer,
+                    "MessageKind : RespondDwalletEncryptedUserShare {:?}",
+                    self.digest()
+                )?;
             }
             DWalletMessageKind::RespondDWalletPartialSignatureVerificationOutput(_) => {
                 writeln!(
                     writer,
-                    "MessageKind : RespondDwalletPartialSignatureVerificationOutput"
+                    "MessageKind : RespondDwalletPartialSignatureVerificationOutput {:?}",
+                    self.digest()
                 )?;
             }
             DWalletMessageKind::RespondDWalletMPCNetworkReconfigurationOutput(_) => {
                 writeln!(
                     writer,
-                    "MessageKind : RespondDWalletMPCNetworkReconfigurationOutput"
+                    "MessageKind : RespondDWalletMPCNetworkReconfigurationOutput {:?}",
+                    self.digest()
                 )?;
             }
             DWalletMessageKind::RespondMakeDWalletUserSecretKeySharesPublic(_) => {
@@ -256,7 +282,8 @@ impl Debug for DWalletMessageKind {
             DWalletMessageKind::RespondDWalletImportedKeyVerificationOutput(_) => {
                 writeln!(
                     writer,
-                    "MessageKind : RespondDWalletImportedKeyVerificationOutput"
+                    "MessageKind : RespondDWalletImportedKeyVerificationOutput {:?}",
+                    self.digest()
                 )?;
             }
             DWalletMessageKind::SetMaxActiveSessionsBuffer(buffer_size) => {

--- a/crates/ika-types/src/message.rs
+++ b/crates/ika-types/src/message.rs
@@ -91,7 +91,7 @@ pub struct DWalletImportedKeyVerificationOutput {
 
 // Note: the order of these fields, and the number must correspond to the Move code in
 // `dwallet_2pc_mpc_coordinator_inner.move`.
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, IntoStaticStr)]
+#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize, IntoStaticStr)]
 pub enum DWalletMessageKind {
     RespondDWalletDKGFirstRoundOutput(DKGFirstRoundOutput),
     RespondDWalletDKGSecondRoundOutput(DKGSecondRoundOutput),


### PR DESCRIPTION
This PR changes our checkpoint debug log to print only the messages digests, giving us better insight if & how the messages differ in the fork that happened on the chain.