### PR TITLE
chore: Restore Class Groups keys only from seed 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3562,6 +3562,8 @@ dependencies = [
  "flate2",
  "group 0.1.0",
  "ika-types",
+ "merlin",
+ "proof",
  "rand 0.9.0",
  "rand_chacha 0.9.0",
  "schemars",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3553,19 +3553,17 @@ name = "dwallet-classgroups-types"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
  "bcs",
  "class_groups",
  "crypto-bigint 0.7.0-pre.5",
  "dwallet-mpc-types",
- "fastcrypto",
+ "dwallet-rng",
  "flate2",
  "group 0.1.0",
  "ika-types",
  "merlin",
  "proof",
  "rand 0.9.0",
- "rand_chacha 0.9.0",
  "schemars",
  "serde",
  "serde_derive",
@@ -3608,6 +3606,20 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "twopc_mpc",
+]
+
+[[package]]
+name = "dwallet-rng"
+version = "1.0.0"
+dependencies = [
+ "base64 0.21.7",
+ "fastcrypto",
+ "group 0.1.0",
+ "ika-types",
+ "merlin",
+ "proof",
+ "rand_chacha 0.9.0",
+ "serde",
 ]
 
 [[package]]
@@ -5602,6 +5614,7 @@ dependencies = [
  "colored",
  "datatest-stable",
  "dwallet-classgroups-types",
+ "dwallet-rng",
  "expect-test",
  "fastcrypto",
  "fs_extra",
@@ -5674,6 +5687,7 @@ dependencies = [
  "dirs 4.0.0",
  "dwallet-classgroups-types",
  "dwallet-mpc-types",
+ "dwallet-rng",
  "fastcrypto",
  "ika-types",
  "once_cell",
@@ -6085,6 +6099,7 @@ dependencies = [
  "bcs",
  "clap",
  "dwallet-classgroups-types",
+ "dwallet-rng",
  "fastcrypto",
  "flate2",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -528,6 +528,7 @@ consensus-core = { git = "https://github.com/MystenLabs/sui", rev = "3b1d6b3bd63
 crypto-bigint = { git = 'https://github.com/erik-3milabs/crypto-bigint.git', rev = "640aacb" }
 
 ### Workspace Members ###
+dwallet-rng = { path = "crates/dwallet-rng" }
 dwallet-mpc-centralized-party = { path = "crates/dwallet-mpc-centralized-party" }
 dwallet-mpc-types = { path = "crates/dwallet-mpc-types"}
 dwallet-classgroups-types = { path = "crates/dwallet-classgroups-types"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 [workspace.dependencies]
 k256 = { version = "0.14.0-pre.7", features = ["arithmetic", "critical-section", "precomputed-tables", "serde", "ecdsa", "hash2curve", "alloc"], default-features = false }
 mpc = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "7dd2b76"}
+proof = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "7dd2b76"}
 class_groups = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "7dd2b76", features = ["threshold"] }
 commitment = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "7dd2b76" }
 twopc_mpc = { git = "https://github.com/dwallet-labs/cryptography-private", features = ["secp256k1", "class_groups"], rev = "7dd2b76"}
@@ -211,6 +212,7 @@ json_to_table = { git = "https://github.com/zhiburt/tabled/", rev = "e449317a1c0
 leb128 = "0.2.5"
 lru = "0.10"
 match_opt = "0.1.2"
+merlin = { version = "3", default-features = false }
 miette = { version = "7", features = ["fancy"] }
 mime = "0.3"
 mockall = "0.11.4"

--- a/crates/dwallet-classgroups-types/Cargo.toml
+++ b/crates/dwallet-classgroups-types/Cargo.toml
@@ -4,8 +4,10 @@ edition = "2021"
 version.workspace = true
 
 [dependencies]
+merlin.workspace = true
 class_groups.workspace = true
 group.workspace = true
+proof.workspace = true
 crypto-bigint.workspace = true
 serde.workspace = true
 anyhow.workspace = true

--- a/crates/dwallet-classgroups-types/Cargo.toml
+++ b/crates/dwallet-classgroups-types/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2021"
 version.workspace = true
 
 [dependencies]
+dwallet-rng.workspace = true
 merlin.workspace = true
 class_groups.workspace = true
 group.workspace = true
@@ -12,8 +13,6 @@ crypto-bigint.workspace = true
 serde.workspace = true
 anyhow.workspace = true
 bcs.workspace = true
-fastcrypto = { workspace = true, features = ["copy_key"] }
-rand_chacha = "0.9"
 schemars.workspace = true
 serde_json.workspace = true
 serde_derive = "1.0.217"
@@ -22,7 +21,6 @@ dwallet-mpc-types.workspace = true
 twopc_mpc.workspace = true
 flate2 = "1.0.35"
 rand.workspace = true
-base64.workspace = true
 
 [lints]
 workspace = true

--- a/crates/dwallet-classgroups-types/src/lib.rs
+++ b/crates/dwallet-classgroups-types/src/lib.rs
@@ -80,6 +80,13 @@ pub struct ClassGroupsKeyPairAndProof {
 }
 
 impl ClassGroupsKeyPairAndProof {
+/// Generates a ClassGroupsKeyPairAndProof from a root seed.
+/// 
+/// This method deterministically generates class group keys using ChaCha20Rng
+/// seeded with the provided root seed. The same seed will always produce
+/// the same key pair.
+/// 
+/// The seed should be cryptographically secure and kept confidential.
     pub fn from_seed(seed: &RootSeed) -> Self {
         let setup_parameters_per_crt_prime =
             construct_setup_parameters_per_crt_prime(DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER)

--- a/crates/dwallet-classgroups-types/src/lib.rs
+++ b/crates/dwallet-classgroups-types/src/lib.rs
@@ -5,14 +5,9 @@ use class_groups::publicly_verifiable_secret_sharing::chinese_remainder_theorem:
     CRT_NON_FUNDAMENTAL_DISCRIMINANT_LIMBS, MAX_PRIMES,
 };
 use class_groups::{CompactIbqf, DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER};
-use crypto_bigint::rand_core::RngCore;
 use crypto_bigint::Uint;
-use fastcrypto::encoding::{Base64, Encoding};
-use group::OsCsRng;
+use dwallet_rng::RootSeed;
 use ika_types::committee::{ClassGroupsEncryptionKeyAndProof, ClassGroupsProof};
-use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
-use merlin::Transcript;
-use rand_chacha::rand_core::SeedableRng;
 use serde::{Deserialize, Serialize};
 
 pub type ClassGroupsDecryptionKey = [Uint<{ CRT_FUNDAMENTAL_DISCRIMINANT_LIMBS }>; MAX_PRIMES];
@@ -28,67 +23,10 @@ pub type SingleEncryptionKeyAndProof = (
 pub const NUM_OF_CLASS_GROUPS_KEY_OBJECTS: usize = MAX_PRIMES;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RootSeed([u8; RootSeed::SEED_LENGTH]);
-
-impl RootSeed {
-    pub const SEED_LENGTH: usize = 32;
-
-    pub fn new(seed: [u8; Self::SEED_LENGTH]) -> Self {
-        RootSeed(seed)
-    }
-
-    /// Generates a cryptographically secure random seed.
-    pub fn random_seed() -> Self {
-        let mut bytes = [0u8; Self::SEED_LENGTH];
-        OsCsRng.fill_bytes(&mut bytes);
-        RootSeed(bytes)
-    }
-
-    /// Reads a class group seed (encoded in Base64) from a file.
-    pub fn from_file<P: AsRef<std::path::Path>>(path: P) -> DwalletMPCResult<Self> {
-        let contents = std::fs::read_to_string(path)
-            .map_err(|e| DwalletMPCError::FailedToReadSeed(e.to_string()))?;
-        let decoded = Base64::decode(contents.as_str())
-            .map_err(|e| DwalletMPCError::FailedToReadSeed(e.to_string()))?;
-        Ok(RootSeed::new(decoded.try_into().map_err(|e| {
-            DwalletMPCError::FailedToReadSeed(format!("failed to read class group seed: {:?}", e))
-        })?))
-    }
-
-    /// Writes the seed, encoded in Base64,
-    /// to a file and returns the encoded seed string.
-    pub fn save_to_file<P: AsRef<std::path::Path> + Clone>(
-        &self,
-        path: P,
-    ) -> DwalletMPCResult<String> {
-        let contents = Base64::encode(self.0);
-        std::fs::write(path.clone(), contents.clone())
-            .map_err(|e| DwalletMPCError::FailedToWriteSeed(e.to_string()))?;
-        Ok(contents)
-    }
-
-    /// Derive a seed for deterministically generating
-    /// this validator's class-groups decryption key and proof [`ClassGroupsKeyPairAndProof`].
-    ///
-    /// We don't use the root seed directly, as it would be used for other purposes
-    /// (such as for generating randomness during an MPC session). Instead, we derive a seed
-    /// from it using a distinct hard-coded label.
-    fn class_groups_decryption_key_seed(&self) -> [u8; Self::SEED_LENGTH] {
-        // Add a distinct descriptive label, and the root seed itself.
-        let mut transcript = Transcript::new(b"Class Groups Decryption Key Seed");
-        transcript.append_message(b"root seed", &self.0);
-
-        // Generate a new seed from it (internally, it uses a hash function to pseudo-randomly generate it).
-        let mut seed: [u8; 32] = [0; 32];
-        transcript.challenge_bytes(b"seed", &mut seed);
-
-        seed
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClassGroupsKeyPairAndProof {
+    #[serde(with = "group::helpers::const_generic_array_serialization")]
     decryption_key_per_crt_prime: ClassGroupsDecryptionKey,
+    #[serde(with = "group::helpers::const_generic_array_serialization")]
     encryption_key_and_proof: ClassGroupsEncryptionKeyAndProof,
 }
 
@@ -110,8 +48,7 @@ impl ClassGroupsKeyPairAndProof {
             )
             .unwrap();
 
-        let seed = root_seed.class_groups_decryption_key_seed();
-        let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed);
+        let mut rng = root_seed.class_groups_decryption_key_rng();
         let decryption_key =
             generate_keypairs_per_crt_prime(setup_parameters_per_crt_prime.clone(), &mut rng)
                 .unwrap();

--- a/crates/dwallet-classgroups-types/src/lib.rs
+++ b/crates/dwallet-classgroups-types/src/lib.rs
@@ -46,11 +46,11 @@ impl RootSeed {
     /// Reads a class group seed (encoded in Base64) from a file.
     pub fn from_file<P: AsRef<std::path::Path>>(path: P) -> DwalletMPCResult<Self> {
         let contents = std::fs::read_to_string(path)
-            .map_err(|e| DwalletMPCError::FailedToReadCGKey(e.to_string()))?;
+            .map_err(|e| DwalletMPCError::FailedToReadSeed(e.to_string()))?;
         let decoded = Base64::decode(contents.as_str())
-            .map_err(|e| DwalletMPCError::FailedToReadCGKey(e.to_string()))?;
+            .map_err(|e| DwalletMPCError::FailedToReadSeed(e.to_string()))?;
         Ok(RootSeed::new(decoded.try_into().map_err(|e| {
-            DwalletMPCError::FailedToReadCGKey(format!("failed to read class group seed: {:?}", e))
+            DwalletMPCError::FailedToReadSeed(format!("failed to read class group seed: {:?}", e))
         })?))
     }
 
@@ -80,13 +80,13 @@ pub struct ClassGroupsKeyPairAndProof {
 }
 
 impl ClassGroupsKeyPairAndProof {
-/// Generates a ClassGroupsKeyPairAndProof from a root seed.
-/// 
-/// This method deterministically generates class group keys using ChaCha20Rng
-/// seeded with the provided root seed. The same seed will always produce
-/// the same key pair.
-/// 
-/// The seed should be cryptographically secure and kept confidential.
+    /// Generates a ClassGroupsKeyPairAndProof from a root seed.
+    ///
+    /// This method deterministically generates class group keys using ChaCha20Rng
+    /// seeded with the provided root seed. The same seed will always produce
+    /// the same key pair.
+    ///
+    /// The seed should be cryptographically secure and kept confidential.
     pub fn from_seed(seed: &RootSeed) -> Self {
         let setup_parameters_per_crt_prime =
             construct_setup_parameters_per_crt_prime(DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER)

--- a/crates/dwallet-classgroups-types/src/lib.rs
+++ b/crates/dwallet-classgroups-types/src/lib.rs
@@ -22,13 +22,12 @@ pub type SingleEncryptionKeyAndProof = (
     CompactIbqf<{ CRT_NON_FUNDAMENTAL_DISCRIMINANT_LIMBS }>,
     ClassGroupsProof,
 );
-
 /// The number of primes used in the class groups key,
 /// each prime corresponds to a dynamic object.
 pub const NUM_OF_CLASS_GROUPS_KEY_OBJECTS: usize = MAX_PRIMES;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RootSeed(pub [u8; RootSeed::SEED_LENGTH]);
+pub struct RootSeed([u8; RootSeed::SEED_LENGTH]);
 
 impl RootSeed {
     pub const SEED_LENGTH: usize = 32;
@@ -37,33 +36,40 @@ impl RootSeed {
         RootSeed(seed)
     }
 
-    pub fn seed(&self) -> [u8; Self::SEED_LENGTH] {
-        self.0
-    }
-
     /// Generates a cryptographically secure random seed.
     pub fn random_seed() -> Self {
         let mut bytes = [0u8; Self::SEED_LENGTH];
         OsCsRng.fill_bytes(&mut bytes);
         RootSeed(bytes)
     }
-}
 
-// impl ClassGroupsDecryptionKey {
-//     pub fn from_seed(
-//         seed: RootSeed,
-//     ) -> Self {
-//         let setup_parameters_per_crt_prime =
-//             construct_setup_parameters_per_crt_prime(DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER).unwrap();
-//
-//         let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed.seed());
-//         ClassGroupsDecryptionKey(generate_keypairs_per_crt_prime(setup_parameters_per_crt_prime.clone(), &mut rng).unwrap())
-//     }
-//
-//     pub fn decryption_key(&self) -> [Uint<{ CRT_FUNDAMENTAL_DISCRIMINANT_LIMBS }>; MAX_PRIMES] {
-//         self.0
-//     }
-// }
+    /// Reads a class group seed (encoded in Base64) from a file.
+    pub fn from_file<P: AsRef<std::path::Path>>(path: P) -> DwalletMPCResult<Self> {
+        let contents = std::fs::read_to_string(path)
+            .map_err(|e| DwalletMPCError::FailedToReadCGKey(e.to_string()))?;
+        let decoded = Base64::decode(contents.as_str())
+            .map_err(|e| DwalletMPCError::FailedToReadCGKey(e.to_string()))?;
+        Ok(RootSeed::new(decoded.try_into().map_err(|e| {
+            DwalletMPCError::FailedToReadCGKey(format!("failed to read class group seed: {:?}", e))
+        })?))
+    }
+
+    /// Writes the seed, encoded in Base64,
+    /// to a file and returns the encoded seed string.
+    pub fn save_to_file<P: AsRef<std::path::Path> + Clone>(
+        &self,
+        path: P,
+    ) -> DwalletMPCResult<String> {
+        let contents = Base64::encode(self.0);
+        std::fs::write(path.clone(), contents.clone())
+            .map_err(|e| DwalletMPCError::FailedToWriteSeed(e.to_string()))?;
+        Ok(contents)
+    }
+
+    pub fn seed(&self) -> [u8; Self::SEED_LENGTH] {
+        self.0
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClassGroupsKeyPairAndProof {
@@ -71,14 +77,6 @@ pub struct ClassGroupsKeyPairAndProof {
     decryption_key_per_crt_prime: ClassGroupsDecryptionKey,
     #[serde(with = "group::helpers::const_generic_array_serialization")]
     encryption_key_and_proof: ClassGroupsEncryptionKeyAndProof,
-}
-
-/// Contains the public keys of the DWallet.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Hash)]
-pub struct DWalletPublicKeys {
-    pub centralized_public_share: Vec<u8>,
-    pub decentralized_public_share: Vec<u8>,
-    pub public_key: Vec<u8>,
 }
 
 impl ClassGroupsKeyPairAndProof {
@@ -92,7 +90,7 @@ impl ClassGroupsKeyPairAndProof {
             )
             .unwrap();
 
-        let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed.0);
+        let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed.seed());
         let decryption_key =
             generate_keypairs_per_crt_prime(setup_parameters_per_crt_prime.clone(), &mut rng)
                 .unwrap();
@@ -117,93 +115,5 @@ impl ClassGroupsKeyPairAndProof {
 
     pub fn decryption_key(&self) -> ClassGroupsDecryptionKey {
         self.decryption_key_per_crt_prime
-    }
-}
-
-/// A wrapper around `ClassGroupsKeyPairAndProof` that ensures the deserialized value
-/// is constructed directly on the heap via `Box`, avoiding large stack allocations.
-///
-/// # Why This Exists
-///
-/// In debug builds, Rust has a significantly smaller stack size compared to release builds.
-/// Deserializing a large or deeply nested struct like `ClassGroupsKeyPairAndProof` directly
-/// can lead to a stack overflow if it's first constructed on the stack before being boxed.
-///
-/// By wrapping the struct inside a `Box` field (`inner`) within this wrapper, we allow the
-/// deserializer (`bcs::from_bytes`) to allocate the entire structure directly on the heap,
-/// bypassing the stack and preventing overflow.
-#[derive(Deserialize)]
-struct ClassGroupsKeyPairAndProofWrapper {
-    inner: Box<ClassGroupsKeyPairAndProof>,
-}
-
-/// Reads a class group key pair and proof (encoded in Base64) from a file.
-pub fn read_class_groups_from_file<P: AsRef<std::path::Path>>(
-    path: P,
-) -> DwalletMPCResult<Box<ClassGroupsKeyPairAndProof>> {
-    let contents = std::fs::read_to_string(path)
-        .map_err(|e| DwalletMPCError::FailedToReadCGKey(e.to_string()))?;
-    let decoded = Base64::decode(contents.as_str())
-        .map_err(|e| DwalletMPCError::FailedToReadCGKey(e.to_string()))?;
-    let keypair: ClassGroupsKeyPairAndProofWrapper = bcs::from_bytes(&decoded)?;
-    Ok(keypair.inner)
-}
-
-/// Writes a class group key seed, encoded in Base64,
-/// to a file and returns the encoded seed string.
-pub fn write_class_groups_seed_to_file<P: AsRef<std::path::Path> + Clone>(
-    seed: [u8; RootSeed::SEED_LENGTH],
-    path: P,
-) -> DwalletMPCResult<String> {
-    let contents = Base64::encode(seed);
-    std::fs::write(path.clone(), contents.clone())
-        .map_err(|e| DwalletMPCError::FailedToWriteCGKey(e.to_string()))?;
-    Ok(contents)
-}
-
-/// Reads a class group seed (encoded in Base64) from a file.
-pub fn read_class_groups_seed_from_file<P: AsRef<std::path::Path>>(
-    path: P,
-) -> DwalletMPCResult<RootSeed> {
-    let contents = std::fs::read_to_string(path)
-        .map_err(|e| DwalletMPCError::FailedToReadCGKey(e.to_string()))?;
-    let decoded = Base64::decode(contents.as_str())
-        .map_err(|e| DwalletMPCError::FailedToReadCGKey(e.to_string()))?;
-    Ok(RootSeed::new(decoded.try_into().map_err(|e| {
-        DwalletMPCError::FailedToReadCGKey(format!("failed to read class group seed: {:?}", e))
-    })?))
-}
-
-pub mod class_groups_as_base64 {
-    use super::*;
-    use base64::engine::general_purpose;
-    use base64::Engine;
-    use serde::de::Error;
-    use serde::{Deserializer, Serializer};
-    use std::sync::Arc;
-
-    pub fn serialize<S>(
-        value: &Arc<impl serde::Serialize>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let bytes = bcs::to_bytes(&**value).map_err(serde::ser::Error::custom)?;
-        let encoded = general_purpose::STANDARD.encode(bytes);
-        serializer.serialize_str(&encoded)
-    }
-
-    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<Arc<T>, D::Error>
-    where
-        D: Deserializer<'de>,
-        T: serde::de::DeserializeOwned,
-    {
-        let encoded = String::deserialize(deserializer)?;
-        let bytes = general_purpose::STANDARD
-            .decode(&encoded)
-            .map_err(Error::custom)?;
-        let value: T = bcs::from_bytes(&bytes).map_err(Error::custom)?;
-        Ok(Arc::new(value))
     }
 }

--- a/crates/dwallet-rng/Cargo.toml
+++ b/crates/dwallet-rng/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "dwallet-rng"
+edition = "2021"
+version.workspace = true
+
+[dependencies]
+merlin.workspace = true
+group.workspace = true
+proof.workspace = true
+fastcrypto.workspace = true
+base64.workspace = true
+ika-types.workspace = true
+rand_chacha.workspace = true
+serde.workspace = true
+
+[lints]
+workspace = true

--- a/crates/dwallet-rng/src/lib.rs
+++ b/crates/dwallet-rng/src/lib.rs
@@ -1,0 +1,74 @@
+use fastcrypto::encoding::{Base64, Encoding};
+use group::OsCsRng;
+use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
+use merlin::Transcript;
+use rand_chacha::rand_core::{RngCore, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootSeed([u8; RootSeed::SEED_LENGTH]);
+
+impl RootSeed {
+    pub const SEED_LENGTH: usize = 32;
+
+    pub fn new(seed: [u8; Self::SEED_LENGTH]) -> Self {
+        RootSeed(seed)
+    }
+
+    /// Generates a cryptographically secure random seed.
+    pub fn random_seed() -> Self {
+        let mut bytes = [0u8; Self::SEED_LENGTH];
+        OsCsRng.fill_bytes(&mut bytes);
+        RootSeed(bytes)
+    }
+
+    /// Reads a class group seed (encoded in Base64) from a file.
+    pub fn from_file<P: AsRef<std::path::Path>>(path: P) -> DwalletMPCResult<Self> {
+        let contents = std::fs::read_to_string(path)
+            .map_err(|e| DwalletMPCError::FailedToReadSeed(e.to_string()))?;
+        let decoded = Base64::decode(contents.as_str())
+            .map_err(|e| DwalletMPCError::FailedToReadSeed(e.to_string()))?;
+        Ok(RootSeed::new(decoded.try_into().map_err(|e| {
+            DwalletMPCError::FailedToReadSeed(format!("failed to read class group seed: {:?}", e))
+        })?))
+    }
+
+    /// Writes the seed, encoded in Base64,
+    /// to a file and returns the encoded seed string.
+    pub fn save_to_file<P: AsRef<std::path::Path> + Clone>(
+        &self,
+        path: P,
+    ) -> DwalletMPCResult<String> {
+        let contents = Base64::encode(self.0);
+        std::fs::write(path.clone(), contents.clone())
+            .map_err(|e| DwalletMPCError::FailedToWriteSeed(e.to_string()))?;
+        Ok(contents)
+    }
+
+    /// Derive a seed for deterministically generating
+    /// this validator's class-groups decryption key and proof [`ClassGroupsKeyPairAndProof`].
+    ///
+    /// We don't use the root seed directly, as it would be used for other purposes
+    /// (such as for generating randomness during an MPC session). Instead, we derive a seed
+    /// from it using a distinct hard-coded label.
+    fn class_groups_decryption_key_seed(&self) -> [u8; Self::SEED_LENGTH] {
+        // Add a distinct descriptive label, and the root seed itself.
+        let mut transcript = Transcript::new(b"Class Groups Decryption Key Seed");
+        transcript.append_message(b"root seed", &self.0);
+
+        // Generate a new seed from it (internally, it uses a hash function to pseudo-randomly generate it).
+        let mut seed: [u8; 32] = [0; 32];
+        transcript.challenge_bytes(b"seed", &mut seed);
+
+        seed
+    }
+
+    /// Instantiates a deterministic secure pseudo-random generator (using the ChaCha20 algorithm)
+    /// with which to generate this validator's class-groups decryption key and proof [`ClassGroupsKeyPairAndProof`].
+    pub fn class_groups_decryption_key_rng(&self) -> ChaCha20Rng {
+        let seed = self.class_groups_decryption_key_seed();
+
+        ChaCha20Rng::from_seed(seed)
+    }
+}

--- a/crates/ika-config/Cargo.toml
+++ b/crates/ika-config/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
+dwallet-rng.workspace = true
 dwallet-mpc-types.workspace = true
 dwallet-classgroups-types.workspace = true
 anemo.workspace = true

--- a/crates/ika-config/src/node.rs
+++ b/crates/ika-config/src/node.rs
@@ -577,7 +577,7 @@ impl RootSeedWithPath {
         let cell: OnceCell<RootSeed> = OnceCell::new();
         // OK to unwrap panic because class_groups should not start without all keypairs loaded.
         cell.set(RootSeed::from_file(path.clone()).unwrap())
-            .expect("Failed to set class_groups keypair");
+            .expect("Failed to set root seed");
         Self {
             location: RootSeedLocation::File { path },
             seed: cell,

--- a/crates/ika-config/src/node.rs
+++ b/crates/ika-config/src/node.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use sui_types::base_types::{ObjectID, SuiAddress};
 
+use dwallet_rng::RootSeed;
 use ika_types::crypto::AuthorityPublicKeyBytes;
 use ika_types::crypto::KeypairTraits;
 use ika_types::crypto::NetworkKeyPair;
@@ -26,7 +27,6 @@ use ika_types::supported_protocol_versions::SupportedProtocolVersions;
 pub use sui_config::node::KeyPairWithPath;
 use sui_types::crypto::SuiKeyPair;
 
-use dwallet_classgroups_types::RootSeed;
 use ika_types::crypto::{
     get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair, EncodeDecodeBase64,
 };

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -149,8 +149,8 @@ impl DWalletMPCManager {
                     .root_seed
                     .clone()
                     // Since only a validator executes the DWalletMPCManager, we can unwrap
-                    // the `class_groups_key_pair_and_proof`.
-                    .expect("Class groups key pair and proof must be present")
+                    // the `root_seed`.
+                    .expect("Root seed must be present")
                     .root_seed(),
             )
             .decryption_key(),

--- a/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
@@ -101,13 +101,11 @@ pub(crate) async fn session_input_from_event(
                 packages_config,
             ) =>
         {
-            let class_groups_key_pair_and_proof = dwallet_mpc_manager
-                .node_config
-                .class_groups_key_pair_and_proof
+            let class_groups_decryption_key = dwallet_mpc_manager
+                .network_keys
+                .validator_private_dec_key_data
+                .class_groups_decryption_key
                 .clone();
-
-            let class_groups_key_pair_and_proof = class_groups_key_pair_and_proof
-                .ok_or(DwalletMPCError::ClassGroupsKeyPairNotFound)?;
 
             Ok((
                 PublicInput::NetworkEncryptionKeyDkg(network_dkg_public_input(
@@ -119,11 +117,7 @@ pub(crate) async fn session_input_from_event(
                         .clone(),
                     DWalletMPCNetworkKeyScheme::Secp256k1,
                 )?),
-                Some(bcs::to_bytes(
-                    &class_groups_key_pair_and_proof
-                        .class_groups_keypair()
-                        .decryption_key(),
-                )?),
+                Some(bcs::to_bytes(&class_groups_decryption_key)?),
             ))
         }
         t if t
@@ -135,13 +129,11 @@ pub(crate) async fn session_input_from_event(
                 DWalletEncryptionKeyReconfigurationRequestEvent,
             > = deserialize_event_or_dynamic_field(&event.contents)?;
 
-            let class_groups_key_pair_and_proof = dwallet_mpc_manager
-                .node_config
-                .class_groups_key_pair_and_proof
+            let class_groups_decryption_key = dwallet_mpc_manager
+                .network_keys
+                .validator_private_dec_key_data
+                .class_groups_decryption_key
                 .clone();
-
-            let class_groups_key_pair_and_proof = class_groups_key_pair_and_proof
-                .ok_or(DwalletMPCError::ClassGroupsKeyPairNotFound)?;
 
             Ok((
                     PublicInput::NetworkEncryptionKeyReconfiguration(<ReconfigurationSecp256k1Party as ReconfigurationPartyPublicInputGenerator>::generate_public_input(
@@ -161,9 +153,7 @@ pub(crate) async fn session_input_from_event(
                             .await?,
                     )?),
                     Some(bcs::to_bytes(
-                        &class_groups_key_pair_and_proof
-                            .class_groups_keypair()
-                            .decryption_key(),
+                        &class_groups_decryption_key
                     )?),
                 ))
         }

--- a/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
@@ -104,8 +104,7 @@ pub(crate) async fn session_input_from_event(
             let class_groups_decryption_key = dwallet_mpc_manager
                 .network_keys
                 .validator_private_dec_key_data
-                .class_groups_decryption_key
-                .clone();
+                .class_groups_decryption_key;
 
             Ok((
                 PublicInput::NetworkEncryptionKeyDkg(network_dkg_public_input(
@@ -132,8 +131,7 @@ pub(crate) async fn session_input_from_event(
             let class_groups_decryption_key = dwallet_mpc_manager
                 .network_keys
                 .validator_private_dec_key_data
-                .class_groups_decryption_key
-                .clone();
+                .class_groups_decryption_key;
 
             Ok((
                     PublicInput::NetworkEncryptionKeyReconfiguration(<ReconfigurationSecp256k1Party as ReconfigurationPartyPublicInputGenerator>::generate_public_input(

--- a/crates/ika-swarm-config/Cargo.toml
+++ b/crates/ika-swarm-config/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
+dwallet-rng.workspace = true
 dwallet-classgroups-types.workspace = true
 anemo.workspace = true
 anyhow.workspace = true

--- a/crates/ika-swarm-config/src/class_groups_mock_builder.rs
+++ b/crates/ika-swarm-config/src/class_groups_mock_builder.rs
@@ -1,5 +1,24 @@
-use dwallet_classgroups_types::read_class_groups_from_file;
 use dwallet_classgroups_types::ClassGroupsKeyPairAndProof;
+use fastcrypto::encoding::{Base64, Encoding};
+use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct ClassGroupsKeyPairAndProofWrapper {
+    inner: Box<ClassGroupsKeyPairAndProof>,
+}
+
+/// Reads a class group key pair and proof (encoded in Base64) from a file.
+fn read_class_groups_from_file<P: AsRef<std::path::Path>>(
+    path: P,
+) -> DwalletMPCResult<Box<ClassGroupsKeyPairAndProof>> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|e| DwalletMPCError::FailedToReadCGKey(e.to_string()))?;
+    let decoded = Base64::decode(contents.as_str())
+        .map_err(|e| DwalletMPCError::FailedToReadCGKey(e.to_string()))?;
+    let keypair: ClassGroupsKeyPairAndProofWrapper = bcs::from_bytes(&decoded)?;
+    Ok(keypair.inner)
+}
 
 pub fn create_full_class_groups_mock() -> Box<ClassGroupsKeyPairAndProof> {
     include_str!("../../../class-groups-keys-mock-files/class-groups-mock-key-full");

--- a/crates/ika-swarm-config/src/class_groups_mock_builder.rs
+++ b/crates/ika-swarm-config/src/class_groups_mock_builder.rs
@@ -13,9 +13,9 @@ fn read_class_groups_from_file<P: AsRef<std::path::Path>>(
     path: P,
 ) -> DwalletMPCResult<Box<ClassGroupsKeyPairAndProof>> {
     let contents = std::fs::read_to_string(path)
-        .map_err(|e| DwalletMPCError::FailedToReadCGKey(e.to_string()))?;
+        .map_err(|e| DwalletMPCError::FailedToReadSeed(e.to_string()))?;
     let decoded = Base64::decode(contents.as_str())
-        .map_err(|e| DwalletMPCError::FailedToReadCGKey(e.to_string()))?;
+        .map_err(|e| DwalletMPCError::FailedToReadSeed(e.to_string()))?;
     let keypair: ClassGroupsKeyPairAndProofWrapper = bcs::from_bytes(&decoded)?;
     Ok(keypair.inner)
 }

--- a/crates/ika-swarm-config/src/network_config_builder.rs
+++ b/crates/ika-swarm-config/src/network_config_builder.rs
@@ -265,12 +265,12 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                         if let Some(rgp) = self.computation_price_per_unit_size {
                             builder = builder.with_computation_price(rgp);
                         }
-                        #[cfg(feature = "mock-class-groups")]
-                        {
-                            builder = builder.with_class_groups_key_pair_and_proof(
-                                crate::class_groups_mock_builder::create_full_class_groups_mock(),
-                            );
-                        }
+                        // #[cfg(feature = "mock-class-groups")]
+                        // {
+                        //     builder = builder.with_root_seed(
+                        //         crate::class_groups_mock_builder::create_full_class_groups_mock(),
+                        //     );
+                        // }
 
                         builder.build(&mut rng)
                     })

--- a/crates/ika-swarm-config/src/network_config_builder.rs
+++ b/crates/ika-swarm-config/src/network_config_builder.rs
@@ -265,12 +265,6 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                         if let Some(rgp) = self.computation_price_per_unit_size {
                             builder = builder.with_computation_price(rgp);
                         }
-                        // #[cfg(feature = "mock-class-groups")]
-                        // {
-                        //     builder = builder.with_root_seed(
-                        //         crate::class_groups_mock_builder::create_full_class_groups_mock(),
-                        //     );
-                        // }
 
                         builder.build(&mut rng)
                     })

--- a/crates/ika-swarm-config/src/node_config_builder.rs
+++ b/crates/ika-swarm-config/src/node_config_builder.rs
@@ -275,15 +275,7 @@ impl FullnodeConfigBuilder {
     ) -> NodeConfig {
         // Take advantage of ValidatorGenesisConfigBuilder to build the keypairs and addresses,
         // even though this is a fullnode.
-        let mut validator_config_builder = ValidatorInitializationConfigBuilder::new();
-
-        // #[cfg(feature = "mock-class-groups")]
-        // {
-        //     validator_config_builder = validator_config_builder
-        //         .with_root_seed(
-        //             ,
-        //         );
-        // }
+        let validator_config_builder = ValidatorInitializationConfigBuilder::new();
 
         let validator_config = validator_config_builder.build(rng);
 

--- a/crates/ika-swarm-config/src/node_config_builder.rs
+++ b/crates/ika-swarm-config/src/node_config_builder.rs
@@ -10,8 +10,8 @@ use fastcrypto::encoding::{Encoding, Hex};
 use fastcrypto::traits::KeyPair;
 use ika_config::node::{
     default_end_of_epoch_broadcast_channel_capacity, AuthorityKeyPairWithPath,
-    AuthorityOverloadConfig, ClassGroupsKeyPairWithPath, KeyPairWithPath, RunWithRange,
-    StateArchiveConfig, SuiChainIdentifier, SuiConnectorConfig,
+    AuthorityOverloadConfig, KeyPairWithPath, RootSeedWithPath, RunWithRange, StateArchiveConfig,
+    SuiChainIdentifier, SuiConnectorConfig,
 };
 use std::path::PathBuf;
 use sui_types::base_types::ObjectID;
@@ -124,9 +124,7 @@ impl ValidatorConfigBuilder {
             ..Default::default()
         };
         NodeConfig {
-            class_groups_key_pair_and_proof: Some(ClassGroupsKeyPairWithPath::new(
-                validator.class_groups_key_pair_and_proof.clone(),
-            )),
+            root_seed: Some(RootSeedWithPath::new(validator.root_seed.clone())),
             protocol_key_pair: AuthorityKeyPairWithPath::new(validator.key_pair.copy()),
             network_key_pair: KeyPairWithPath::new(SuiKeyPair::Ed25519(
                 validator.network_key_pair.copy(),
@@ -279,13 +277,13 @@ impl FullnodeConfigBuilder {
         // even though this is a fullnode.
         let mut validator_config_builder = ValidatorInitializationConfigBuilder::new();
 
-        #[cfg(feature = "mock-class-groups")]
-        {
-            validator_config_builder = validator_config_builder
-                .with_class_groups_key_pair_and_proof(
-                    crate::class_groups_mock_builder::create_full_class_groups_mock(),
-                );
-        }
+        // #[cfg(feature = "mock-class-groups")]
+        // {
+        //     validator_config_builder = validator_config_builder
+        //         .with_root_seed(
+        //             ,
+        //         );
+        // }
 
         let validator_config = validator_config_builder.build(rng);
 
@@ -332,7 +330,7 @@ impl FullnodeConfigBuilder {
         let notifier_client_key_pair = notifier_client_key_pair.map(KeyPairWithPath::new);
 
         NodeConfig {
-            class_groups_key_pair_and_proof: None,
+            root_seed: None,
             protocol_key_pair: AuthorityKeyPairWithPath::new(validator_config.key_pair),
             account_key_pair: KeyPairWithPath::new(validator_config.account_key_pair),
             consensus_key_pair: KeyPairWithPath::new(SuiKeyPair::Ed25519(

--- a/crates/ika-swarm-config/src/validator_initialization_config.rs
+++ b/crates/ika-swarm-config/src/validator_initialization_config.rs
@@ -49,8 +49,13 @@ pub struct ValidatorInitializationConfig {
 impl ValidatorInitializationConfig {
     pub fn to_validator_info(&self) -> ValidatorInfo {
         let name = self.name.clone().unwrap_or("".to_string());
-        let class_groups_public_key_and_proof =
-            ClassGroupsKeyPairAndProof::from_seed(&self.root_seed).encryption_key_and_proof();
+
+        let class_groups_public_key_and_proof = if cfg!(feature = "mock-class-groups") {
+            crate::class_groups_mock_builder::create_full_class_groups_mock()
+                .encryption_key_and_proof()
+        } else {
+            ClassGroupsKeyPairAndProof::from_seed(&self.root_seed).encryption_key_and_proof()
+        };
         let protocol_public_key: AuthorityPublicKeyBytes = self.key_pair.public().into();
         let account_key: PublicKey = self.account_key_pair.public();
         let network_public_key: NetworkPublicKey = self.network_key_pair.public().clone();

--- a/crates/ika-swarm-config/src/validator_initialization_config.rs
+++ b/crates/ika-swarm-config/src/validator_initialization_config.rs
@@ -3,9 +3,7 @@
 
 use std::net::{IpAddr, SocketAddr};
 
-use dwallet_classgroups_types::{
-    generate_class_groups_keypair_and_proof_from_seed, sample_seed, ClassGroupsKeyPairAndProof,
-};
+use dwallet_classgroups_types::{ClassGroupsKeyPairAndProof, RootSeed};
 use fastcrypto::traits::KeyPair;
 use ika_config::initiation::MIN_VALIDATOR_JOINING_STAKE_INKU;
 use ika_config::local_ip_utils;
@@ -26,7 +24,7 @@ pub const DEFAULT_NUMBER_OF_AUTHORITIES: usize = 4;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ValidatorInitializationConfig {
     pub name: Option<String>,
-    pub class_groups_key_pair_and_proof: Box<ClassGroupsKeyPairAndProof>,
+    pub root_seed: RootSeed,
     #[serde(default = "default_bls12381_key_pair")]
     pub key_pair: AuthorityKeyPair,
     #[serde(default = "default_ed25519_key_pair")]
@@ -51,9 +49,8 @@ pub struct ValidatorInitializationConfig {
 impl ValidatorInitializationConfig {
     pub fn to_validator_info(&self) -> ValidatorInfo {
         let name = self.name.clone().unwrap_or("".to_string());
-        let class_groups_public_key_and_proof = self
-            .class_groups_key_pair_and_proof
-            .encryption_key_and_proof();
+        let class_groups_public_key_and_proof =
+            ClassGroupsKeyPairAndProof::from_seed(&self.root_seed).encryption_key_and_proof();
         let protocol_public_key: AuthorityPublicKeyBytes = self.key_pair.public().into();
         let account_key: PublicKey = self.account_key_pair.public();
         let network_public_key: NetworkPublicKey = self.network_key_pair.public().clone();
@@ -89,7 +86,7 @@ impl ValidatorInitializationConfig {
 pub struct ValidatorInitializationConfigBuilder {
     protocol_key_pair: Option<AuthorityKeyPair>,
     account_key_pair: Option<AccountKeyPair>,
-    class_groups_key_pair_and_proof: Option<Box<ClassGroupsKeyPairAndProof>>,
+    root_seed: Option<RootSeed>,
     ip: Option<String>,
     computation_price: Option<u64>,
     /// If set, the validator will use deterministic addresses based on the port offset.
@@ -114,11 +111,8 @@ impl ValidatorInitializationConfigBuilder {
         self
     }
 
-    pub fn with_class_groups_key_pair_and_proof(
-        mut self,
-        key_pair: Box<ClassGroupsKeyPairAndProof>,
-    ) -> Self {
-        self.class_groups_key_pair_and_proof = Some(key_pair);
+    pub fn with_root_seed(mut self, root_seed: RootSeed) -> Self {
+        self.root_seed = Some(root_seed);
         self
     }
 
@@ -158,13 +152,10 @@ impl ValidatorInitializationConfigBuilder {
         let computation_price = self
             .computation_price
             .unwrap_or(DEFAULT_VALIDATOR_COMPUTATION_PRICE);
-        let class_groups_key_pair_and_proof = self
-            .class_groups_key_pair_and_proof
+        let root_seed = self
+            .root_seed
             .clone()
-            .unwrap_or_else(|| {
-                let seed = sample_seed();
-                Box::new(generate_class_groups_keypair_and_proof_from_seed(seed))
-            });
+            .unwrap_or_else(|| RootSeed::random_seed());
 
         let (consensus_key_pair, network_key_pair): (NetworkKeyPair, NetworkKeyPair) =
             (get_key_pair_from_rng(rng).1, get_key_pair_from_rng(rng).1);
@@ -200,7 +191,7 @@ impl ValidatorInitializationConfigBuilder {
 
         ValidatorInitializationConfig {
             key_pair: protocol_key_pair,
-            class_groups_key_pair_and_proof,
+            root_seed,
             consensus_key_pair,
             account_key_pair: account_key_pair.into(),
             network_key_pair,

--- a/crates/ika-swarm-config/src/validator_initialization_config.rs
+++ b/crates/ika-swarm-config/src/validator_initialization_config.rs
@@ -157,10 +157,7 @@ impl ValidatorInitializationConfigBuilder {
         let computation_price = self
             .computation_price
             .unwrap_or(DEFAULT_VALIDATOR_COMPUTATION_PRICE);
-        let root_seed = self
-            .root_seed
-            .clone()
-            .unwrap_or_else(RootSeed::random_seed);
+        let root_seed = self.root_seed.clone().unwrap_or_else(RootSeed::random_seed);
 
         let (consensus_key_pair, network_key_pair): (NetworkKeyPair, NetworkKeyPair) =
             (get_key_pair_from_rng(rng).1, get_key_pair_from_rng(rng).1);

--- a/crates/ika-swarm-config/src/validator_initialization_config.rs
+++ b/crates/ika-swarm-config/src/validator_initialization_config.rs
@@ -3,7 +3,8 @@
 
 use std::net::{IpAddr, SocketAddr};
 
-use dwallet_classgroups_types::{ClassGroupsKeyPairAndProof, RootSeed};
+use dwallet_classgroups_types::ClassGroupsKeyPairAndProof;
+use dwallet_rng::RootSeed;
 use fastcrypto::traits::KeyPair;
 use ika_config::initiation::MIN_VALIDATOR_JOINING_STAKE_INKU;
 use ika_config::local_ip_utils;

--- a/crates/ika-swarm-config/src/validator_initialization_config.rs
+++ b/crates/ika-swarm-config/src/validator_initialization_config.rs
@@ -160,7 +160,7 @@ impl ValidatorInitializationConfigBuilder {
         let root_seed = self
             .root_seed
             .clone()
-            .unwrap_or_else(|| RootSeed::random_seed());
+            .unwrap_or_else(RootSeed::random_seed);
 
         let (consensus_key_pair, network_key_pair): (NetworkKeyPair, NetworkKeyPair) =
             (get_key_pair_from_rng(rng).1, get_key_pair_from_rng(rng).1);

--- a/crates/ika-types/src/dwallet_mpc_error.rs
+++ b/crates/ika-types/src/dwallet_mpc_error.rs
@@ -100,7 +100,7 @@ pub enum DwalletMPCError {
     #[error("failed to read Class Groups key: {0}")]
     FailedToReadCGKey(String),
 
-    #[error("failed to write Class Groups key: {0}")]
+    #[error("failed to write seed to file: {0}")]
     FailedToWriteSeed(String),
 
     #[error("missing MPC private session input")]

--- a/crates/ika-types/src/dwallet_mpc_error.rs
+++ b/crates/ika-types/src/dwallet_mpc_error.rs
@@ -97,8 +97,8 @@ pub enum DwalletMPCError {
     #[error("error in Class Groups: {0}")]
     ClassGroupsError(String),
 
-    #[error("failed to read Class Groups key: {0}")]
-    FailedToReadCGKey(String),
+    #[error("failed to read seed from file: {0}")]
+    FailedToReadSeed(String),
 
     #[error("failed to write seed to file: {0}")]
     FailedToWriteSeed(String),

--- a/crates/ika-types/src/dwallet_mpc_error.rs
+++ b/crates/ika-types/src/dwallet_mpc_error.rs
@@ -101,7 +101,7 @@ pub enum DwalletMPCError {
     FailedToReadCGKey(String),
 
     #[error("failed to write Class Groups key: {0}")]
-    FailedToWriteCGKey(String),
+    FailedToWriteSeed(String),
 
     #[error("missing MPC private session input")]
     MissingMPCPrivateInput,

--- a/crates/ika/Cargo.toml
+++ b/crates/ika/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 anyhow.workspace = true
 bin-version.workspace = true
 bcs.workspace = true
+dwallet-rng.workspace = true
 dwallet-classgroups-types.workspace = true
 clap.workspace = true
 datatest-stable.workspace = true

--- a/crates/ika/src/validator_commands.rs
+++ b/crates/ika/src/validator_commands.rs
@@ -9,10 +9,7 @@ use sui_types::{base_types::SuiAddress, multiaddr::Multiaddr};
 
 use clap::*;
 use colored::Colorize;
-use dwallet_classgroups_types::{
-    read_class_groups_seed_from_file, write_class_groups_seed_to_file, ClassGroupsKeyPairAndProof,
-    RootSeed,
-};
+use dwallet_classgroups_types::{ClassGroupsKeyPairAndProof, RootSeed};
 use fastcrypto::traits::KeyPair;
 use ika_config::node::read_authority_keypair_from_file;
 use ika_config::validator_info::ValidatorInfo;
@@ -422,7 +419,7 @@ fn read_or_generate_seed_and_class_groups_key(
     seed_path: PathBuf,
 ) -> Result<Box<ClassGroupsKeyPairAndProof>> {
     println!("Generating class groups key pair file",);
-    let seed = match read_class_groups_seed_from_file(seed_path.clone()) {
+    let seed = match RootSeed::from_file(seed_path.clone()) {
         Ok(seed) => {
             println!("Use existing seed: {:?}.", seed_path,);
             seed
@@ -430,7 +427,7 @@ fn read_or_generate_seed_and_class_groups_key(
         Err(err) => {
             println!("error reading class groups key from file: {err:?}, generating...");
             let seed = RootSeed::random_seed();
-            write_class_groups_seed_to_file(seed.seed(), seed_path.clone())?;
+            seed.save_to_file(seed_path.clone())?;
             println!(
                 "Generated class groups key pair info file: {:?}.",
                 seed_path,

--- a/crates/ika/src/validator_commands.rs
+++ b/crates/ika/src/validator_commands.rs
@@ -10,9 +10,8 @@ use sui_types::{base_types::SuiAddress, multiaddr::Multiaddr};
 use clap::*;
 use colored::Colorize;
 use dwallet_classgroups_types::{
-    generate_class_groups_keypair_and_proof_from_seed, read_class_groups_from_file,
-    read_class_groups_seed_from_file, sample_seed, write_class_groups_keypair_and_proof_to_file,
-    write_class_groups_seed_to_file, ClassGroupsKeyPairAndProof,
+    read_class_groups_seed_from_file, write_class_groups_seed_to_file, ClassGroupsKeyPairAndProof,
+    RootSeed,
 };
 use fastcrypto::traits::KeyPair;
 use ika_config::node::read_authority_keypair_from_file;
@@ -153,10 +152,8 @@ impl IkaValidatorCommand {
                     read_network_keypair_from_file(network_key_file_name)?;
                 let pop = generate_proof_of_possession(&keypair, sender_sui_address);
 
-                let class_groups_public_key_and_proof = read_or_generate_seed_and_class_groups_key(
-                    dir.join("class-groups.key"),
-                    dir.join("class-groups.seed"),
-                )?;
+                let class_groups_public_key_and_proof =
+                    read_or_generate_seed_and_class_groups_key(dir.join("class-groups.seed"))?;
 
                 let validator_info = ValidatorInfo {
                     name,
@@ -419,34 +416,30 @@ fn make_key_files(
     Ok(())
 }
 
-/// Reads the class groups a key pair and proof from a file if it exists,
-/// otherwise generates it from the seed.
-/// The seed is the private key of the authority key pair.
+/// Generates the class groups a key pair and proof from a seed file if it exists,
+/// otherwise generates and saves the seed.
 fn read_or_generate_seed_and_class_groups_key(
-    file_path: PathBuf,
     seed_path: PathBuf,
 ) -> Result<Box<ClassGroupsKeyPairAndProof>> {
     println!("Generating class groups key pair file",);
-    match read_class_groups_from_file(file_path.clone()) {
-        Ok(class_groups_public_key_and_proof) => {
-            println!("Use existing: {:?}.", file_path,);
-            Ok(class_groups_public_key_and_proof)
+    let seed = match read_class_groups_seed_from_file(seed_path.clone()) {
+        Ok(seed) => {
+            println!("Use existing seed: {:?}.", seed_path,);
+            seed
         }
         Err(err) => {
             println!("error reading class groups key from file: {err:?}, generating...");
-            let seed = read_class_groups_seed_from_file(seed_path.clone()).unwrap_or(sample_seed());
-            let class_groups_public_key_and_proof =
-                Box::new(generate_class_groups_keypair_and_proof_from_seed(seed));
-            write_class_groups_keypair_and_proof_to_file(
-                &class_groups_public_key_and_proof,
-                file_path.clone(),
-            )?;
-            write_class_groups_seed_to_file(seed, seed_path.clone())?;
+            let seed = RootSeed::random_seed();
+            write_class_groups_seed_to_file(seed.seed(), seed_path.clone())?;
             println!(
                 "Generated class groups key pair info file: {:?}.",
-                file_path,
+                seed_path,
             );
-            Ok(class_groups_public_key_and_proof)
+            seed
         }
-    }
+    };
+
+    let class_groups_public_key_and_proof = Box::new(ClassGroupsKeyPairAndProof::from_seed(&seed));
+
+    Ok(class_groups_public_key_and_proof)
 }

--- a/crates/ika/src/validator_commands.rs
+++ b/crates/ika/src/validator_commands.rs
@@ -9,7 +9,8 @@ use sui_types::{base_types::SuiAddress, multiaddr::Multiaddr};
 
 use clap::*;
 use colored::Colorize;
-use dwallet_classgroups_types::{ClassGroupsKeyPairAndProof, RootSeed};
+use dwallet_classgroups_types::ClassGroupsKeyPairAndProof;
+use dwallet_rng::RootSeed;
 use fastcrypto::traits::KeyPair;
 use ika_config::node::read_authority_keypair_from_file;
 use ika_config::validator_info::ValidatorInfo;


### PR DESCRIPTION
Store only the seed file and generate the key pair from the seed.