### PR TITLE
refactor: ed25519 address calculation gas optimizations

### DIFF
--- a/crates/ika-move-packages/packages/ika_common/sources/address.move
+++ b/crates/ika-move-packages/packages/ika_common/sources/address.move
@@ -3,15 +3,13 @@
 
 module ika_common::address;
 
-// === Imports ===
-
 use sui::{address, hash};
+
+// === Imports ===
 
 // === Public Functions ===
 
 public fun ed25519_address(public_key: vector<u8>): address {
-    let mut hasher = vector[0u8];
-    hasher.append(public_key);
-    let address_bytes = hash::blake2b256(&hasher);
+    let address_bytes = hash::blake2b256(&public_key);
     address::from_bytes(address_bytes)
 }


### PR DESCRIPTION
## Description 

ed25519 address calculation can be changed to not append into an another vector for gas optimizations, it is almost saves 4x more gas from the internal tests i did.

The results can be checked via `sui move test -s`.

<img width="970" alt="image" src="https://github.com/user-attachments/assets/081ec957-eb04-49ac-969b-4926c473608f" />