### PR TITLE
fix: Use current pricing instead of default pricing when charging MPC flows

### DIFF
--- a/crates/ika-move-packages/packages/ika_dwallet_2pc_mpc/sources/pricing_and_fee_manager.move
+++ b/crates/ika-move-packages/packages/ika_dwallet_2pc_mpc/sources/pricing_and_fee_manager.move
@@ -186,7 +186,7 @@ public(package) fun get_pricing_value_for_protocol(
     protocol: u32,
 ): PricingInfoValue {
     let mut pricing_value = self
-        .default
+        .current
         .try_get_pricing_value(curve, signature_algorithm, protocol);
     assert!(pricing_value.is_some(), EMissingProtocolPricing);
     pricing_value.extract()


### PR DESCRIPTION
## Description 

Until now the default pricing was used, which was always 0, basically causing all the MPC flows to be free of charge. This PR fixes this issue and by using current pricing.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
